### PR TITLE
`RPM` and `AppImage` packaging support using flutter_distributor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ list.csv
 *.mo
 RELEASING.md
 BUILDING.md
+dist/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "quickgui",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "quickgui (profile mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "quickgui (release mode)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "release"
+    }
+  ]
+}

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -1,0 +1,5 @@
+appId: com.example.quickgui
+icon: assets/images/logo.png
+
+include:
+  - zenity

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -1,0 +1,15 @@
+display_name: Quickgui
+package_name: quickgui
+maintainer:
+  name: Yannick Mauray
+  email: yannick.mauray@gmail.com
+
+dependencies:
+  - zenity
+section: x11
+priority: optional
+installed_size: 6604
+essential: false
+icon: assets/images/logo.png
+
+startup_notify: true

--- a/linux/packaging/rpm/make_config.yaml
+++ b/linux/packaging/rpm/make_config.yaml
@@ -1,0 +1,15 @@
+summary: A Flutter frontend for quickget and quickemu
+group: Application/Emulator
+vendor: Quick Project
+packager: Yannick Mauray
+packagerEmail: yannick.mauray@gmail.com
+url: https://github.com/quickemu-project/quickgui
+icon: assets/images/logo.png
+license: Unknown
+
+requires:
+  - zenity
+
+display_name: Quickgui
+essential: false
+startup_notify: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: quickgui
 description: A new Flutter project.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 1.2.8-1
+version: 1.2.8+1
 
 environment:
   sdk: ">=2.14.4 <3.0.0"
@@ -35,6 +35,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.0
+  flutter_distributor:
+    git:
+      url: https://github.com/KRTirtho/flutter_distributor
+      path: packages/flutter_distributor
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
This PR adds:

- RPM packaging support
- AppImage packaging support (untested)
- Deb packaging support (through flutter_distributor, not Makefile)
- Fixes wrong `semver` versioning convention (use `+` to indicate build number instead of `-`)

The version of `flutter_distributor` used on this PR is from [krtirtho/flutter_distributor](https://github.com/krtirtho/flutter_distributor) as the official https://github.com/leanflutter/flutter_distributor/pull/101 isn't merged yet

> This PR also adds possibility of easy packaging of [windows executable](https://distributor.leanflutter.org/docs/makers/exe) and [macOS disk image](https://distributor.leanflutter.org/docs/makers/dmg) too


Thanks for this awesome project. Keep fluttering :fire: :blue_heart: :rocket: :muscle: 