### PR TITLE
refactor: update loadOperatingSystems to use quickget --list-csv

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'src/model/version.dart';
 import 'src/model/osicons.dart';
 
 Future<List<OperatingSystem>> loadOperatingSystems(bool showUbuntus) async {
-  var process = await Process.run('quickget', ['list_csv']);
+  var process = await Process.run('quickget', ['--list-csv']);
   var stdout = process.stdout as String;
   var output = <OperatingSystem>[];
 


### PR DESCRIPTION
- Close #124

`quickemu list_csv` is deprecated and `quickemu --list-csv` provide the same functionality.
