### PR TITLE
fix: update download progress parsing to support curl's output

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,7 +34,7 @@ Future<List<OperatingSystem>> loadOperatingSystems(bool showUbuntus) async {
     Tuple5 supportedVersion;
     if (chunks.length == 4) // Legacy version of quickget
     {
-      supportedVersion = Tuple5.fromList([...chunks, "wget"]);
+      supportedVersion = Tuple5.fromList([...chunks, "curl"]);
     } else {
       var t5 = [chunks[0], chunks[1], chunks[2], chunks[3], chunks[4]].toList();
       supportedVersion = Tuple5.fromList(t5);

--- a/lib/src/pages/downloader.dart
+++ b/lib/src/pages/downloader.dart
@@ -32,7 +32,6 @@ class Downloader extends StatefulWidget {
 class _DownloaderState extends State<Downloader> {
   final notificationsClient = NotificationsClient();
   final wgetPattern = RegExp("( [0-9.]+%)");
-  final ariaPattern = RegExp("([0-9.]+%)");
   late final Stream<double> _progressStream;
   bool _downloadFinished = false;
   var controller = StreamController<double>();
@@ -55,17 +54,6 @@ class _DownloaderState extends State<Downloader> {
     }
   }
 
-  void parseAriaProgress(String line) {
-    var matches = ariaPattern.allMatches(line).toList();
-    if (matches.isNotEmpty) {
-      var percent = matches[0].group(1);
-      if (percent != null) {
-        var value = double.parse(percent.replaceAll('%', '')) / 100.0;
-        controller.add(value);
-      }
-    }
-  }
-
   Stream<double> progressStream() {
     var options = [widget.operatingSystem.code, widget.version.version];
     if (widget.option != null) {
@@ -76,8 +64,6 @@ class _DownloaderState extends State<Downloader> {
         process.stderr.transform(utf8.decoder).forEach(parseWgetProgress);
       } else if (widget.option!.downloader == 'zsync') {
         controller.add(-1);
-      } else if (widget.option!.downloader == 'aria2c') {
-        process.stderr.transform(utf8.decoder).forEach(parseAriaProgress);
       }
 
       process.exitCode.then((value) {
@@ -132,8 +118,7 @@ class _DownloaderState extends State<Downloader> {
               stream: _progressStream,
               builder: (context, AsyncSnapshot<double> snapshot) {
                 var data = !snapshot.hasData ||
-                        widget.option!.downloader != 'wget' ||
-                        widget.option!.downloader != 'aria2c'
+                        widget.option!.downloader != 'wget'
                     ? null
                     : snapshot.data;
                 return Column(

--- a/lib/src/pages/downloader.dart
+++ b/lib/src/pages/downloader.dart
@@ -31,7 +31,7 @@ class Downloader extends StatefulWidget {
 
 class _DownloaderState extends State<Downloader> {
   final notificationsClient = NotificationsClient();
-  final wgetPattern = RegExp("( [0-9.]+%)");
+  final curlPattern = RegExp("( [0-9.]+%)");
   late final Stream<double> _progressStream;
   bool _downloadFinished = false;
   var controller = StreamController<double>();
@@ -43,8 +43,8 @@ class _DownloaderState extends State<Downloader> {
     super.initState();
   }
 
-  void parseWgetProgress(String line) {
-    var matches = wgetPattern.allMatches(line).toList();
+  void parseCurlProgress(String line) {
+    var matches = curlPattern.allMatches(line).toList();
     if (matches.isNotEmpty) {
       var percent = matches[0].group(1);
       if (percent != null) {
@@ -60,9 +60,9 @@ class _DownloaderState extends State<Downloader> {
       options.add(widget.option!.option);
     }
     Process.start('quickget', options).then((process) {
-      if (widget.option!.downloader == 'wget') {
-        process.stderr.transform(utf8.decoder).forEach(parseWgetProgress);
-      } else if (widget.option!.downloader == 'zsync') {
+      if (widget.option!.downloader != 'zsync') {
+        process.stderr.transform(utf8.decoder).forEach(parseCurlProgress);
+      } else {
         controller.add(-1);
       }
 
@@ -118,7 +118,7 @@ class _DownloaderState extends State<Downloader> {
               stream: _progressStream,
               builder: (context, AsyncSnapshot<double> snapshot) {
                 var data = !snapshot.hasData ||
-                        widget.option!.downloader != 'wget'
+                        widget.option!.downloader != 'curl'
                     ? null
                     : snapshot.data;
                 return Column(

--- a/lib/src/pages/downloader.dart
+++ b/lib/src/pages/downloader.dart
@@ -32,7 +32,6 @@ class Downloader extends StatefulWidget {
 class _DownloaderState extends State<Downloader> {
   final notificationsClient = NotificationsClient();
   final wgetPattern = RegExp("( [0-9.]+%)");
-  final macRecoveryPattern = RegExp("([0-9]+\\.[0-9])");
   final ariaPattern = RegExp("([0-9.]+%)");
   late final Stream<double> _progressStream;
   bool _downloadFinished = false;
@@ -67,17 +66,6 @@ class _DownloaderState extends State<Downloader> {
     }
   }
 
-  void parseMacRecoveryProgress(String line) {
-    var matches = macRecoveryPattern.allMatches(line).toList();
-    if (matches.isNotEmpty) {
-      var size = matches[0].group(1);
-      if (size != null) {
-        var value = double.parse(size);
-        controller.add(value);
-      }
-    }
-  }
-
   Stream<double> progressStream() {
     var options = [widget.operatingSystem.code, widget.version.version];
     if (widget.option != null) {
@@ -88,10 +76,6 @@ class _DownloaderState extends State<Downloader> {
         process.stderr.transform(utf8.decoder).forEach(parseWgetProgress);
       } else if (widget.option!.downloader == 'zsync') {
         controller.add(-1);
-      } else if (widget.option!.downloader == 'macrecovery') {
-        process.stdout
-            .transform(utf8.decoder)
-            .forEach(parseMacRecoveryProgress);
       } else if (widget.option!.downloader == 'aria2c') {
         process.stderr.transform(utf8.decoder).forEach(parseAriaProgress);
       }

--- a/lib/src/widgets/downloader/download_label.dart
+++ b/lib/src/widgets/downloader/download_label.dart
@@ -21,7 +21,7 @@ class DownloadLabel extends StatelessWidget {
           ? Text(context.t('Download finished.'))
           : data != null
               ? downloader != 'zsync'
-                  ? downloader == 'wget' || downloader == 'aria2c'
+                  ? downloader == 'curl' || downloader == ''
                       ? Text(context.t('Downloading... {0}%',
                           args: [(data! * 100).toInt()]))
                       : Text(context.t('{0} Mbs downloaded', args: [data!]))


### PR DESCRIPTION
Since Quickemu 4.9.3 `quickget` downloads everything, except Ubuntu daily images, with curl via the `web_get()` function internal to `quickget`.

This pull request drops support for `wget`, `aria2` and `macrecovery` progress parsing as none of these are used by `quickget` anymore. It also adapts the progress parsing to `curl`'s progress output and accounts for a bug in `quickget` where it stopped reporting if `wget`/`curl` is the external download tool in the csv data.