### PR TITLE
chore: temporarily force light mode

### DIFF
--- a/lib/src/model/app_settings.dart
+++ b/lib/src/model/app_settings.dart
@@ -38,7 +38,8 @@ class AppSettings extends ChangeNotifier {
   }
 
   set useDarkModeSilently(bool useDarkMode) {
-    _themeMode = useDarkMode ? ThemeMode.dark : ThemeMode.light;
+    //_themeMode = useDarkMode ? ThemeMode.dark : ThemeMode.light;
+    _themeMode = ThemeMode.light;
   }
 
   set useDarkMode(bool useDarkMode) {

--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -48,6 +48,7 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                 title: Text("quickgui $_version",
                     style: Theme.of(context).textTheme.titleLarge),
               ),
+              /*
               const Divider(),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -71,6 +72,7 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                   ],
                 ),
               ),
+              */
               const Divider(),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),


### PR DESCRIPTION
Dark mode doesn't render some icons correctly at the moment and in an effort to get an update Quickgui release out light mode the temporarily the only theme.
