### PR TITLE
fix: prevent flickering while left_menu slides in

### DIFF
--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -52,7 +52,9 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                 title: Text("Quickgui $_version",
                   style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
               ),
-              const Divider(),
+              Container(
+                height: 4.0,
+              ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Row(
@@ -86,7 +88,9 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                   ],
                 ),
               ),
-              const Divider(),
+              Container(
+                height: 4.0,
+              ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Row(

--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -50,7 +50,7 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
             children: [
               ListTile(
                 title: Text("Quickgui $_version",
-                    style: Theme.of(context).textTheme.titleLarge),
+                  style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
               ),
               const Divider(),
               Padding(

--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -16,11 +16,15 @@ class LeftMenu extends StatefulWidget {
 }
 
 class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
+  List<DropdownMenuItem<String>> _dropdownMenuItems = [];
   late String currentLocale;
 
   @override
   void initState() {
     super.initState();
+    _dropdownMenuItems = supportedLocales
+      .map((e) => DropdownMenuItem(child: Text(e), value: e))
+      .toList();
   }
 
   @override
@@ -93,10 +97,7 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                     ),
                     DropdownButton<String>(
                       value: currentLocale,
-                      items: supportedLocales
-                          .map(
-                              (e) => DropdownMenuItem(child: Text(e), value: e))
-                          .toList(),
+                      items: _dropdownMenuItems,
                       onChanged: (value) {
                         setState(() {
                           currentLocale = value!;


### PR DESCRIPTION
While the menu slides in from the left it causes the whole app to flicker and stutter.

This patch caches the `supportedLocales` at `initState()` and replaces `Divider()` with `Container()`. The two `Divider()` were largely responsible for the ugly flickering and replacing the with `Conatiner()` keeps things flicker free.