### PR TITLE
ci: only test build quickgui if the flutter app was changed

### DIFF
--- a/.github/workflows/build-quickgui.yml
+++ b/.github/workflows/build-quickgui.yml
@@ -4,9 +4,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - pubspec.yaml
+      - assets/**
+      - lib/**
+      - linux/**
   push:
     branches:
       - main
+    paths:
+      - pubspec.yaml
+      - assets/**
+      - lib/**
+      - linux/**
   workflow_dispatch:
 
 # TODO: arm64 runner


### PR DESCRIPTION
# Description

Test builds of the Quickgui Flutter app are always being triggered. This patch only triggers test builds of the app, if the app was actually changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
