### PR TITLE
feat: add fetchQuickemuVersion() and display version in the menu

### DIFF
--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -4,3 +4,15 @@ var gIsSnap = Platform.environment['SNAP']?.isNotEmpty ?? false;
 const String prefWorkingDirectory = 'workingDirectory';
 const String prefThemeMode = 'themeMode';
 const String prefCurrentLocale = 'currentLocale';
+
+Future<String> fetchQuickemuVersion() async {
+  // Get the version of quickemu
+  var result = await Process.run('quickemu', ['--version']);
+
+  // If successful return the trimmed version
+  if (result.exitCode == 0) {
+    return result.stdout.trim();
+  } else {
+    return '';
+  }
+}

--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -22,6 +22,7 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
   @override
   void initState() {
     super.initState();
+    fetchQuickemuVersion();
     _dropdownMenuItems = supportedLocales
       .map((e) => DropdownMenuItem(child: Text(e), value: e))
       .toList();
@@ -48,9 +49,35 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
         return Drawer(
           child: ListView(
             children: [
-              ListTile(
-                title: Text("Quickgui $_version",
-                  style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
+              Padding(
+                // Minimal bottom padding
+                padding: EdgeInsets.only(bottom: 0).add(EdgeInsets.symmetric(horizontal: 16)),
+                child: Container(
+                  padding: EdgeInsets.symmetric(vertical: 4.0),
+                  child: Text("Quickgui $_version",
+                    style: const TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
+                ),
+              ),
+              FutureBuilder<String>(
+                future: fetchQuickemuVersion(),
+                builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return CircularProgressIndicator(); // or some other widget while waiting
+                  } else {
+                    String poweredByText = context.t('Powered by') + " Quickemu";
+                    if (snapshot.hasData) {
+                      poweredByText += " ${snapshot.data}";
+                    }
+                    return Padding(
+                      // Minimal top padding
+                      padding: EdgeInsets.only(top: 0).add(EdgeInsets.symmetric(horizontal: 16)),
+                      child: Container(
+                        child: Text(poweredByText,
+                          style: const TextStyle(fontSize: 12.0, fontWeight: FontWeight.bold)),
+                        ),
+                    );
+                  }
+                },
               ),
               Container(
                 height: 4.0,


### PR DESCRIPTION
# Description

The patch adds `fetchQuickemuVersion()` and uses it to display the Quickemu version being used by Quickgui. 

- Resolves #169

![quickgui_powered_by](https://github.com/quickemu-project/quickgui/assets/304639/4a6ced34-c5b4-4a23-adad-e2a5713d9080)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
