### PR TITLE
feat: kill VMs using quickemu --kill when running quickemu >= 4.9.6

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -882,6 +882,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  version:
+    dependency: "direct main"
+    description:
+      name: version
+      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.lock.json
+++ b/pubspec.lock.json
@@ -1100,6 +1100,16 @@
       "source": "hosted",
       "version": "2.1.4"
     },
+    "version": {
+      "dependency": "direct main",
+      "description": {
+        "name": "version",
+        "sha256": "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.2"
+    },
     "vm_service": {
       "dependency": "transitive",
       "description": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   url_launcher: ^6.3.0
   shared_preferences: ^2.2.3
   tuple: ^2.0.2
+  version: ^3.0.2
   window_size:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git


### PR DESCRIPTION
# Description

This patch checks the available Quickemu version. If >= 4.9.6 is available, Quickgui will use the new Quickemu `--kill` option to terminate VMs. The existing `killall <processname>` will be used for older versions of Quickemu.

This change is being made because `--kill` is macOS compatible, whereas `killall <processname>` is only supported on Linux because QEMU on macOS can not set the process name for a VM.

- Resolves #170

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
