### PR TITLE
feat: nix package, overlay and devshell use the quickemu FlakeHub flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,24 +14,59 @@
         "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/%2A.tar.gz"
       }
     },
-    "nixpkgs": {
+    "flake-schemas_2": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
-        "revCount": 644565,
+        "lastModified": 1697467827,
+        "narHash": "sha256-j8SR19V1SRysyJwpOBF4TLuAvAjF5t+gMiboN4gYQDU=",
+        "rev": "764932025c817d4e500a8d2a4d8c565563923d29",
+        "revCount": 29,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.644565%2Brev-b2852eb9365c6de48ffb0dc2c9562591f652242a/01906511-d0fc-7244-b596-2d790f5bfdb0/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.2/018b3da8-4cc3-7fbb-8ff7-1588413c53e2/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/%2A.tar.gz"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717952948,
+        "narHash": "sha256-mJi4/gjiwQlSaxjA6AusXBN/6rQRaPCycR7bd8fydnQ=",
+        "rev": "2819fffa7fa42156680f0d282c60d81e8fb185b7",
+        "revCount": 631440,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.631440%2Brev-2819fffa7fa42156680f0d282c60d81e8fb185b7/0190034c-678d-7039-b45c-fa38168f2500/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A.tar.gz"
+      }
+    },
+    "quickemu": {
+      "inputs": {
+        "flake-schemas": "flake-schemas_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719316513,
+        "narHash": "sha256-9EQMWByMD0K0mRFKO+CtTFRWREaePB6xU6jBmtVhF3U=",
+        "rev": "1c89f520f2c7d10cc9cc1d15b8cae32215359224",
+        "revCount": 1992,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/quickemu-project/quickemu/4.9.5/01904f50-5263-7e22-b58e-a1dae34d5486/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/quickemu-project/quickemu/%2A.tar.gz"
       }
     },
     "root": {
       "inputs": {
         "flake-schemas": "flake-schemas",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "quickemu": "quickemu"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,37 +2,46 @@
   description = "Quickgui flake";
   inputs = {
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*.tar.gz";
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*.tar.gz";
+    quickemu.url = "https://flakehub.com/f/quickemu-project/quickemu/*.tar.gz";
+    quickemu.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {
     self,
     flake-schemas,
     nixpkgs,
+    quickemu,
   }: let
-    forAllSystems = function:
-      nixpkgs.lib.genAttrs [
-        "x86_64-linux"
-        # TODO: Enable when upstream supports these platforms
-        #"aarch64-linux"
-        #"x86_64-darwin"
-        #"aarch64-darwin"
-      ] (system: function nixpkgs.legacyPackages.${system});
+      # Define supported systems and a helper function for generating system-specific outputs
+      #TODO: Add the following as quickemu/quickgui/GitHub builders support them:
+      #      aarch64-darwin aarch64-linux x86_64-darwin
+      supportedSystems = [ "x86_64-linux" ];
+
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        system = system;
+        pkgs = import nixpkgs { inherit system; };
+      });
   in {
-    # Schemas tell Nix about the structure of your flake's outputs
+    # Define schemas for the flake's outputs
     schemas = flake-schemas.schemas;
 
-    overlays.default = final: prev: {
-      quickgui = final.callPackage ./package.nix {};
-    };
+    # Define overlays for each supported system
+    overlays = forEachSupportedSystem ({pkgs, system, ...}: {
+      default = final: prev: {
+        quickgui = final.callPackage ./package.nix { quickemu = quickemu.packages.${system}.default; };
+      };
+    });
 
-    packages = forAllSystems (pkgs: rec {
-      quickgui = pkgs.callPackage ./package.nix {};
+    # Define packages for each supported system
+    packages = forEachSupportedSystem ({pkgs, system, ...}: rec {
+      quickgui = pkgs.callPackage ./package.nix { quickemu = quickemu.packages.${system}.default; };
       default = quickgui;
     });
 
-    devShells = forAllSystems (pkgs: {
-      default = pkgs.callPackage ./devshell.nix {};
+    # Define devShells for each supported system
+    devShells = forEachSupportedSystem ({pkgs, system, ...}: {
+      default = pkgs.callPackage ./devshell.nix { quickemu = quickemu.packages.${system}.default; };
     });
   };
 }


### PR DESCRIPTION
# Description

This updates the Nix flake to include the current stable release of Quickemu via the FlakeHub flake and always tracks the Nixpkgs stable branch.

- All future Quickgui releases will now also include the stable release of Quickemu.
- Nix devshell now have the current Quickemu version included, directly from us (upstream) rather than potentially out-of-date releases from Nixpkgs
- The builds tool in the Nix devshell track the 6-monthly stable branch of Nixpkgs for better predictability.

## Type of change

- [x] Packaging (updates the packaging)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections