### PR TITLE
fix: check for running VM processes using kill -0

### DIFF
--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -156,8 +156,10 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
         File pidFile = File('$name/$name.pid');
         if (pidFile.existsSync()) {
           String pid = pidFile.readAsStringSync().trim();
-          Directory procDir = Directory('/proc/$pid');
-          if (procDir.existsSync()) {
+          // Check if the process is still running using kill -0, which is
+          // a portable way to check if a process is running on macOS and Linux.
+          ProcessResult result = Process.runSync('kill', ['-0', pid]);
+          if (result.exitCode == 0) {
             if (_activeVms.containsKey(name)) {
               activeVms[name] = _activeVms[name]!;
             } else {


### PR DESCRIPTION
# Description

Change how VM processes are inspected to test if they are running but using `kill -0 <pid>`. Use `kill -0` is portable between macOS and Linux and the BSD and GNU tools. `quickemu` also uses `kill -0`, which was introduced as part of the macOS porting work.

I've tested this on Linux to make sure there are no regressions; it needs validating on macOS.

- Fixes #179

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections