### PR TITLE
docs: fix Ubuntu ppa repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ systemPackages = with pkgs; [
 Ubuntu users can install Quickgui using the [.deb package described above for Debian](#debian) or from our PPA.
 
 ```shell
-sudo add-apt-repository ppa:flexiondotorg/quickgui
+sudo apt-add-repository ppa:flexiondotorg/quickemu
 sudo apt-get update
 sudo apt-get install quickgui
 ```


### PR DESCRIPTION
# Description

Went through the installation and found that there is a typo in the README.

```
$ sudo add-apt-repository ppa:flexiondotorg/quickgui
ERROR: ppa 'flexiondotorg/quickgui' not found (use --login if private)
```

But with the quickemu instructions it all work:

```
$ sudo apt-add-repository ppa:flexiondotorg/quickemu
...
$ sudo apt-get install quickgui
(all good)
```

Seems that the right ppa is the same as the one for quickemu and one with `quickgui` in it.

- Related #196 (ticket seems related, although they mention Asahi, I am on vanilla Ubuntu)

## Type of change

- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have made corresponding changes to the documentation
