### PR TITLE
fix: repoint CONTRIBUTING discussion link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome contributions to Quickgui.
 
-- Help other Quickgui users by answering questions in the [Quickgui Discussions](https://github.com/quickemu-project/quickgui/discussions) 🛟
+- Help other Quickgui users by answering questions in the [Quickgui Discussions](https://github.com/quickemu-project/discussions/categories/quickgui) 🛟
 - Improve the documentation in [this README](https://github.com/quickemu-project/quickgui/edit/master/README.md) and the [Quickgui Wiki](https://github.com/quickemu-project/quickgui/wiki) 📖
 - File bug reports and feature requests in the [Quickgui Issues](https://github.com/quickemu-project/quickgui/issues) 📁
 - Submit [Quickgui Pull requests](https://github.com/quickemu-project/quickgui/pulls) to fix bugs 🐞 or add new features ✨


### PR DESCRIPTION
# Description

Point the contributors towards project-level discussion rather than a 404.

- Closes #204
( if a project wiki is enabled)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (updates the documentation)
