### PR TITLE
fix: #216 Increase max and default window size on Linux

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ void main() async {
     setWindowMaxSize(const Size(692 + 2, 580 + 30));
   } else {
     setWindowMinSize(const Size(692, 580));
-    setWindowMaxSize(const Size(692, 580));
+    setWindowMaxSize(const Size(800, 720));
   }
   final foundQuickGet = await Process.run('which', ['quickget']);
   if (foundQuickGet.exitCode == 0) {

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -47,7 +47,7 @@ static void my_application_activate(GApplication* application) {
     gtk_window_set_title(window, "quickgui");
   }
 
-  gtk_window_set_default_size(window, 692, 580);
+  gtk_window_set_default_size(window, 800, 720);
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();


### PR DESCRIPTION
# Description

Increase the max and default window size on Linux desktop to prevent the buttons being chopped off in some circumstances, with no way to resize the window and get to them.

I have left the minimum window size as before, so users for who this is not a problem can still reduce the window size if desired.

<!-- Delete if not relevant -->
- Fixes #216

## Type of change

<!-- Delete any that are not relevant -->

- [ x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!-- Delete any that are not relevant -->

- [ x ] I have performed a self-review of my code
- [ x ] I have tested my code in common scenarios and confirmed there are no regressions
