### PR TITLE
vm conf editor added

### DIFF
--- a/lib/src/model/vm_config.dart
+++ b/lib/src/model/vm_config.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+class VmConfig {
+  final String name;
+  final File file;
+  String rawContent = '';
+
+  VmConfig({required this.name, required String confPath})
+      : file = File(confPath);
+
+  Future<void> load() async {
+    if (file.existsSync()) {
+      rawContent = await file.readAsString();
+    }
+  }
+
+  Future<void> save(String updatedContent) async {
+    rawContent = updatedContent;
+    await file.writeAsString(rawContent);
+  }
+}

--- a/lib/src/pages/vm_config_editor.dart
+++ b/lib/src/pages/vm_config_editor.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../model/vm_config.dart';
+
+class VmConfigEditorDialog extends StatefulWidget {
+  final String vmName;
+  final String confPath;
+
+  const VmConfigEditorDialog({
+    super.key,
+    required this.vmName,
+    required this.confPath,
+  });
+
+  @override
+  State<VmConfigEditorDialog> createState() => _VmConfigEditorDialogState();
+}
+
+class _VmConfigEditorDialogState extends State<VmConfigEditorDialog> {
+  late VmConfig config;
+  final TextEditingController _editorController = TextEditingController();
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    config = VmConfig(name: widget.vmName, confPath: widget.confPath);
+    config.load().then((_) {
+      _editorController.text = config.rawContent;
+      setState(() => _loading = false);
+    });
+  }
+
+  void _save() async {
+    await config.save(_editorController.text);
+    if(!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  void _openDocs() async {
+    const url = 'https://github.com/quickemu-project/quickemu/blob/master/docs/quickemu_conf.5.md';
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Edit VM: ${widget.vmName}'),
+      content: _loading
+          ? const SizedBox(height: 100, child: Center(child: CircularProgressIndicator()))
+          : SizedBox(
+              width: double.maxFinite,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(config.file.path,
+                      style: const TextStyle(fontSize: 12, color: Colors.grey)),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton.icon(
+                      icon: const Icon(Icons.help_outline),
+                      label: const Text("Open config documentation"),
+                      onPressed: _openDocs,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Flexible(
+                    child: TextField(
+                      controller: _editorController,
+                      maxLines: null,
+                      keyboardType: TextInputType.multiline,
+                      style: const TextStyle(fontFamily: 'monospace'),
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        contentPadding: EdgeInsets.all(8),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: _save,
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
# Description

Introduced a new VM config editor window that allows users to directly view and edit the raw `.conf` file of a virtual machine using a simple text editor interface. 

Also included:
- Edit, Save or Cancel functionality.
- Only inactive VMs can be edited to prevent conflicts.
- Link to official Quickemu `.conf` documentation for reference.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
