### PR TITLE
build!: update Flutter desktop compatibility

### DIFF
--- a/.github/workflows/build-quickgui.yml
+++ b/.github/workflows/build-quickgui.yml
@@ -2,27 +2,48 @@ name: Build Quickgui 🏗️
 
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-      - pubspec.yaml
-      - assets/**
-      - lib/**
-      - linux/**
+    branches: [main]
   push:
-    branches:
-      - main
-    paths:
-      - pubspec.yaml
-      - assets/**
-      - lib/**
-      - linux/**
+    branches: [main]
   workflow_dispatch:
 
-# TODO: arm64 runner
-# https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  analyze-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: pubspec.yaml
+      - run: flutter pub get --enforce-lockfile
+      - run: dart format --output=none --set-exit-if-changed lib test
+      - run: flutter analyze
+      - run: flutter test
+
+  test-build-macos:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: pubspec.yaml
+      - run: flutter pub get --enforce-lockfile
+      - run: flutter build macos --release
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Quickgui-macos
+          path: build/macos/Build/Products/Release/quickgui.app
+          if-no-files-found: error
+
   test-build-linux-x64:
     runs-on: ubuntu-22.04
     steps:
@@ -53,6 +74,7 @@ jobs:
           overwrite: true
 
   test-build-ppa-x64:
+    if: github.repository == 'quickemu-project/quickgui' && github.event_name != 'pull_request'
     runs-on: ubuntu-22.04
     steps:
       - name: "Checkout 🥡"
@@ -127,4 +149,3 @@ jobs:
         run: |
           nix build .#quickgui
           tree ./result
-

--- a/.github/workflows/publish-quickgui.yml
+++ b/.github/workflows/publish-quickgui.yml
@@ -58,24 +58,24 @@ jobs:
           sudo apt-get -y install clang cmake libblkid1 liblzma5 libgtk-3-0 libgtk-3-dev ninja-build pkg-config
       - name: Install Flutter dependencies 🦋
         run: flutter pub get
-      - name: Activate flutter_distributor 🚀
-        run: dart pub global activate flutter_distributor
+      - name: Activate fastforge 🚀
+        run: dart pub global activate fastforge 0.6.12
       - name: Build AppImage 🐧
         run: |
           sudo apt-get -y install libfuse-dev locate
           wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O /usr/local/bin/appimagetool
           chmod +x /usr/local/bin/appimagetool
-          flutter_distributor package --platform=linux --targets=appimage
+          fastforge package --platform=linux --targets=appimage
       - name: Build .deb 🍥
         run: |
           sudo apt-get -y install dpkg
-          flutter_distributor package --platform=linux --targets=deb
+          fastforge package --platform=linux --targets=deb
       - name: Build .rpm 🎩
         run: |
           sudo apt-get -y install patchelf rpm
-          flutter_distributor package --platform=linux --targets=rpm
+          fastforge package --platform=linux --targets=rpm
       - name: Build .zip 🤐
-        run: flutter_distributor package --platform=linux --targets=zip
+        run: fastforge package --platform=linux --targets=zip
       - name: Show artifacts 👀
         run: tree dist/
       - name: "Publish Release 📤️"
@@ -93,6 +93,7 @@ jobs:
           gh release edit "${{ github.ref }}" --draft=false
 
   publish-flakehub:
+    if: github.repository == 'quickemu-project/quickgui'
     needs: [version-check]
     name: "Publish FlakeHub ❄️"
     runs-on: "ubuntu-22.04"
@@ -112,6 +113,7 @@ jobs:
           tag: "${{ inputs.tag }}"
 
   publish-ppa-x64:
+    if: github.repository == 'quickemu-project/quickgui'
     needs: [version-check]
     name: "Publish PPA (x64) 🟠"
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ list.csv
 *.mo
 RELEASING.md
 BUILDING.md
+
+# macOS Finder metadata
+.DS_Store

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,11 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/devshell.nix
+++ b/devshell.nix
@@ -11,7 +11,7 @@
   dpkg,
   flutter,
   git,
-  gnome,
+  zenity,
   gtk3,
   ninja,
   patchelf,
@@ -32,7 +32,7 @@ mkShell rec {
     dpkg
     flutter
     git
-    gnome.zenity
+    zenity
     gtk3
     ninja
     patchelf
@@ -50,10 +50,10 @@ mkShell rec {
     flutter pub get
     yq eval pubspec.lock -o=json -P > pubspec.lock.json
     flutter config --enable-linux-desktop
-    dart pub global activate flutter_distributor
+    dart pub global activate fastforge 0.6.12
     echo "**********************************************************************"
     echo "* flutter build linux --release                                      *"
-    echo "* flutter_distributor package --platform=linux --targets=zip         *"
+    echo "* fastforge package --platform=linux --targets=zip                  *"
     echo "**********************************************************************"
     if [ -z "$PUB_CACHE" ]; then
       export PATH="$PATH":"$HOME/.pub-cache/bin"

--- a/flake.lock
+++ b/flake.lock
@@ -66,7 +66,24 @@
       "inputs": {
         "flake-schemas": "flake-schemas",
         "nixpkgs": "nixpkgs",
-        "quickemu": "quickemu"
+        "quickemu": "quickemu",
+        "flutter-nixpkgs": "flutter-nixpkgs"
+      }
+    },
+    "flutter-nixpkgs": {
+      "locked": {
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   inputs = {
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*.tar.gz";
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*.tar.gz";
+    flutter-nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     quickemu.url = "https://flakehub.com/f/quickemu-project/quickemu/*.tar.gz";
     quickemu.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -11,6 +12,7 @@
     self,
     flake-schemas,
     nixpkgs,
+    flutter-nixpkgs,
     quickemu,
   }: let
       # Define supported systems and a helper function for generating system-specific outputs
@@ -21,27 +23,28 @@
       forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
         system = system;
         pkgs = import nixpkgs { inherit system; };
+        flutter = (import flutter-nixpkgs { inherit system; }).flutter;
       });
   in {
     # Define schemas for the flake's outputs
     schemas = flake-schemas.schemas;
 
     # Define overlays for each supported system
-    overlays = forEachSupportedSystem ({pkgs, system, ...}: {
+    overlays = forEachSupportedSystem ({pkgs, system, flutter, ...}: {
       default = final: prev: {
-        quickgui = final.callPackage ./package.nix { quickemu = quickemu.packages.${system}.default; };
+        quickgui = final.callPackage ./package.nix { inherit flutter; quickemu = quickemu.packages.${system}.default; };
       };
     });
 
     # Define packages for each supported system
-    packages = forEachSupportedSystem ({pkgs, system, ...}: rec {
-      quickgui = pkgs.callPackage ./package.nix { quickemu = quickemu.packages.${system}.default; };
+    packages = forEachSupportedSystem ({pkgs, system, flutter, ...}: rec {
+      quickgui = pkgs.callPackage ./package.nix { inherit flutter; quickemu = quickemu.packages.${system}.default; };
       default = quickgui;
     });
 
     # Define devShells for each supported system
-    devShells = forEachSupportedSystem ({pkgs, system, ...}: {
-      default = pkgs.callPackage ./devshell.nix { quickemu = quickemu.packages.${system}.default; };
+    devShells = forEachSupportedSystem ({pkgs, system, flutter, ...}: {
+      default = pkgs.callPackage ./devshell.nix { inherit flutter; quickemu = quickemu.packages.${system}.default; };
     });
   };
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -30,37 +29,46 @@ Future<List<OperatingSystem>> loadOperatingSystems(bool showUbuntus) async {
       .where((element) => element.isNotEmpty)
       .map((e) => e.trim())
       .forEach((element) {
-    var chunks = element.split(",");
-    Tuple5 supportedVersion;
-    if (chunks.length == 4) // Legacy version of quickget
-    {
-      supportedVersion = Tuple5.fromList([...chunks, "curl"]);
-    } else {
-      var t5 = [chunks[0], chunks[1], chunks[2], chunks[3], chunks[4]].toList();
-      supportedVersion = Tuple5.fromList(t5);
-    }
+        var chunks = element.split(",");
+        Tuple5 supportedVersion;
+        if (chunks.length == 4) // Legacy version of quickget
+        {
+          supportedVersion = Tuple5.fromList([...chunks, "curl"]);
+        } else {
+          var t5 = [
+            chunks[0],
+            chunks[1],
+            chunks[2],
+            chunks[3],
+            chunks[4],
+          ].toList();
+          supportedVersion = Tuple5.fromList(t5);
+        }
 
-    if (currentOperatingSystem?.code != supportedVersion.item2) {
-      currentOperatingSystem =
-          OperatingSystem(supportedVersion.item1, supportedVersion.item2);
-      output.add(currentOperatingSystem!);
-      currentVersion = null;
-    }
-    if (currentVersion?.version != supportedVersion.item3) {
-      currentVersion = Version(supportedVersion.item3);
-      currentOperatingSystem!.versions.add(currentVersion!);
-    }
-    currentVersion!.options
-        .add(Option(supportedVersion.item4, supportedVersion.item5));
-  });
+        if (currentOperatingSystem?.code != supportedVersion.item2) {
+          currentOperatingSystem = OperatingSystem(
+            supportedVersion.item1,
+            supportedVersion.item2,
+          );
+          output.add(currentOperatingSystem!);
+          currentVersion = null;
+        }
+        if (currentVersion?.version != supportedVersion.item3) {
+          currentVersion = Version(supportedVersion.item3);
+          currentOperatingSystem!.versions.add(currentVersion!);
+        }
+        currentVersion!.options.add(
+          Option(supportedVersion.item4, supportedVersion.item5),
+        );
+      });
 
   return output;
 }
 
 Future<void> getIcons() async {
-  final manifestContent = await rootBundle.loadString('AssetManifest.json');
-  final Map<String, dynamic> manifestMap = json.decode(manifestContent);
-  final imagePaths = manifestMap.keys
+  final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+  final imagePaths = manifest
+      .listAssets()
       .where((String key) => key.contains('quickemu-icons/'))
       .where((String key) => key.contains('.svg'))
       .toList();
@@ -84,14 +92,12 @@ void main() async {
   final foundQuickGet = await Process.run('which', ['quickget']);
   if (foundQuickGet.exitCode == 0) {
     gOperatingSystems = loadOperatingSystems(false);
-    getIcons();
+    await getIcons();
     AppVersion.packageInfo = await PackageInfo.fromPlatform();
   }
   runApp(
     MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (_) => AppSettings()),
-      ],
+      providers: [ChangeNotifierProvider(create: (_) => AppSettings())],
       builder: (context, _) => const App(),
     ),
   );

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -51,8 +51,8 @@ class _AppState extends State<App> with PreferencesMixin {
             snapshot.data != null) {
           var appSettings = context.read<AppSettings>();
           appSettings.setActiveLocaleSilently(
-              snapshot.data?.getString(prefCurrentLocale) ??
-                  Platform.localeName);
+            snapshot.data?.getString(prefCurrentLocale) ?? Platform.localeName,
+          );
           var pref = snapshot.data!.getBool(prefThemeMode);
           if (pref != null) {
             appSettings.useDarkModeSilently = pref;
@@ -60,11 +60,12 @@ class _AppState extends State<App> with PreferencesMixin {
           return Consumer<AppSettings>(
             builder: (context, appSettings, _) => MaterialApp(
               theme: ThemeData(
-                  useMaterial3: true,
-                  colorScheme: ColorScheme.fromSwatch(
-                    primarySwatch: Colors.pink,
-                    backgroundColor: Colors.white,
-                  )),
+                useMaterial3: true,
+                colorScheme: ColorScheme.fromSwatch(
+                  primarySwatch: Colors.pink,
+                  backgroundColor: Colors.white,
+                ),
+              ),
               darkTheme: ThemeData(
                 useMaterial3: true,
                 colorScheme: ColorScheme.fromSwatch(
@@ -77,27 +78,34 @@ class _AppState extends State<App> with PreferencesMixin {
               home: AppVersion.packageInfo == null
                   ? const DebgetNotFoundPage()
                   : const MainPage(),
-              supportedLocales: supportedLocales.map((s) => s.contains("_")
-                  ? Locale(s.split("_")[0], s.split("_")[1])
-                  : Locale(s)),
+              supportedLocales: supportedLocales.map(
+                (s) => s.contains("_")
+                    ? Locale(s.split("_")[0], s.split("_")[1])
+                    : Locale(s),
+              ),
               localizationsDelegates: [
                 GettextLocalizationsDelegate(),
                 ...GlobalMaterialLocalizations.delegates,
                 GlobalWidgetsLocalizations.delegate,
               ],
-              locale:
-                  Locale(appSettings.languageCode!, appSettings.countryCode),
+              locale: Locale(
+                appSettings.languageCode!,
+                appSettings.countryCode,
+              ),
               localeListResolutionCallback: (locales, supportedLocales) {
                 if (locales != null) {
                   for (var locale in locales) {
-                    var supportedLocale = supportedLocales.where((element) =>
-                        element.languageCode == locale.languageCode &&
-                        element.countryCode == locale.countryCode);
+                    var supportedLocale = supportedLocales.where(
+                      (element) =>
+                          element.languageCode == locale.languageCode &&
+                          element.countryCode == locale.countryCode,
+                    );
                     if (supportedLocale.isNotEmpty) {
                       return supportedLocale.first;
                     }
-                    supportedLocale = supportedLocales.where((element) =>
-                        element.languageCode == locale.languageCode);
+                    supportedLocale = supportedLocales.where(
+                      (element) => element.languageCode == locale.languageCode,
+                    );
                     if (supportedLocale.isNotEmpty) {
                       return supportedLocale.first;
                     }
@@ -108,9 +116,7 @@ class _AppState extends State<App> with PreferencesMixin {
             ),
           );
         } else {
-          return const Center(
-            child: CircularProgressIndicator(),
-          );
+          return const Center(child: CircularProgressIndicator());
         }
       },
     );

--- a/lib/src/model/app_settings.dart
+++ b/lib/src/model/app_settings.dart
@@ -14,15 +14,15 @@ class AppSettings extends ChangeNotifier {
   String? get languageCode => _activeLocale?.split("_")[0];
   String? get countryCode =>
       ((_activeLocale != null) && (_activeLocale!.contains("_")))
-          ? _activeLocale!.split("_")[1]
-          : null;
+      ? _activeLocale!.split("_")[1]
+      : null;
 
   set activeLocale(String locale) {
     _activeLocale = locale;
     notifyListeners();
   }
 
-  setActiveLocaleSilently(String locale) {
+  void setActiveLocaleSilently(String locale) {
     _activeLocale = locale;
     if (_activeLocale!.contains(".")) {
       _activeLocale = _activeLocale!.split(".")[0];

--- a/lib/src/pages/debget_not_found_page.dart
+++ b/lib/src/pages/debget_not_found_page.dart
@@ -15,27 +15,17 @@ class DebgetNotFoundPage extends StatelessWidget {
           children: [
             Text(
               context.t('quickemu was not found in your PATH'),
-              style: const TextStyle(
-                fontSize: 24,
-              ),
+              style: const TextStyle(fontSize: 24),
             ),
-            const SizedBox(
-              height: 16,
-            ),
+            const SizedBox(height: 16),
             Text(
               context.t('Please install it and try again.'),
-              style: const TextStyle(
-                fontSize: 24,
-              ),
+              style: const TextStyle(fontSize: 24),
             ),
-            const SizedBox(
-              height: 16,
-            ),
+            const SizedBox(height: 16),
             Text.rich(
               TextSpan(
-                style: const TextStyle(
-                  fontSize: 16,
-                ),
+                style: const TextStyle(fontSize: 16),
                 text: context.t('See'),
                 children: [
                   TextSpan(
@@ -43,7 +33,8 @@ class DebgetNotFoundPage extends StatelessWidget {
                       ..onTap = () {
                         launchUrl(
                           Uri.parse(
-                              'https://github.com/quickemu-project/quickemu'),
+                            'https://github.com/quickemu-project/quickemu',
+                          ),
                         );
                       },
                     text: ' github.com/quickemu-project/quickemu ',

--- a/lib/src/pages/downloader.dart
+++ b/lib/src/pages/downloader.dart
@@ -26,7 +26,7 @@ class Downloader extends StatefulWidget {
   final Option? option;
 
   @override
-  _DownloaderState createState() => _DownloaderState();
+  State<Downloader> createState() => _DownloaderState();
 }
 
 class _DownloaderState extends State<Downloader> {
@@ -67,15 +67,15 @@ class _DownloaderState extends State<Downloader> {
       }
 
       process.exitCode.then((value) {
-        bool _cancelled = value.isNegative;
+        bool cancelled = value.isNegative;
         controller.close();
         setState(() {
           _downloadFinished = true;
           notificationsClient?.notify(
-            _cancelled
+            cancelled
                 ? context.t('Download cancelled')
                 : context.t('Download complete'),
-            body: _cancelled
+            body: cancelled
                 ? context.t(
                     'Download of {0} has been canceled.',
                     args: [widget.operatingSystem.name],
@@ -85,7 +85,7 @@ class _DownloaderState extends State<Downloader> {
                     args: [widget.operatingSystem.name],
                   ),
             appName: 'Quickgui',
-            expireTimeoutMs: 10000, /* 10 seconds */
+            expireTimeoutMs: 10000 /* 10 seconds */,
           );
         });
       });
@@ -102,12 +102,12 @@ class _DownloaderState extends State<Downloader> {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          context.t('Downloading {0}', args: [
-            '${widget.operatingSystem.name} ${widget.version.version}' +
-                (widget.option!.option.isNotEmpty
-                    ? ' (${widget.option!.option})'
-                    : '')
-          ]),
+          context.t(
+            'Downloading {0}',
+            args: [
+              '${widget.operatingSystem.name} ${widget.version.version}${widget.option!.option.isNotEmpty ? ' (${widget.option!.option})' : ''}',
+            ],
+          ),
         ),
         automaticallyImplyLeading: false,
       ),
@@ -117,8 +117,8 @@ class _DownloaderState extends State<Downloader> {
             child: StreamBuilder(
               stream: _progressStream,
               builder: (context, AsyncSnapshot<double> snapshot) {
-                var data = !snapshot.hasData ||
-                        widget.option!.downloader != 'curl'
+                var data =
+                    !snapshot.hasData || widget.option!.downloader != 'curl'
                     ? null
                     : snapshot.data;
                 return Column(
@@ -135,8 +135,12 @@ class _DownloaderState extends State<Downloader> {
                     ),
                     Padding(
                       padding: const EdgeInsets.only(top: 32),
-                      child: Text(context.t('Target folder : {0}',
-                          args: [Directory.current.path])),
+                      child: Text(
+                        context.t(
+                          'Target folder : {0}',
+                          args: [Directory.current.path],
+                        ),
+                      ),
                     ),
                   ],
                 );

--- a/lib/src/pages/downloader_page.dart
+++ b/lib/src/pages/downloader_page.dart
@@ -10,15 +10,8 @@ class DownloaderPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(context.t('Downloader')),
-      ),
-      body: const Column(
-        children: [
-          Logo(),
-          DownloaderMenu(),
-        ],
-      ),
+      appBar: AppBar(title: Text(context.t('Downloader'))),
+      body: const Column(children: [Logo(), DownloaderMenu()]),
     );
   }
 }

--- a/lib/src/pages/main_page.dart
+++ b/lib/src/pages/main_page.dart
@@ -18,7 +18,8 @@ class _MainPageState extends State<MainPage> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     setWindowTitle(
-        context.t('Quickgui : a Flutter frontend for Quickget and Quickemu'));
+      context.t('Quickgui : a Flutter frontend for Quickget and Quickemu'),
+    );
   }
 
   @override
@@ -31,12 +32,7 @@ class _MainPageState extends State<MainPage> {
         foregroundColor: Theme.of(context).colorScheme.onPrimary,
       ),
       drawer: const LeftMenu(),
-      body: const Column(
-        children: [
-          Logo(),
-          MainMenu(),
-        ],
-      ),
+      body: const Column(children: [Logo(), MainMenu()]),
     );
   }
 }

--- a/lib/src/pages/manager.dart
+++ b/lib/src/pages/manager.dart
@@ -60,17 +60,20 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     _getTerminalEmulator();
     _detectSpice();
     getPreference<String>(prefWorkingDirectory).then((pref) {
+      if (!mounted) return;
       setState(() {
         if (pref == null) {
           return;
         }
         Directory.current = pref;
       });
-      Future.delayed(Duration.zero,
-          () => _getVms(context)); // Reload VM list when we enter the page.
+      Future.delayed(
+        Duration.zero,
+        () => _getVms(),
+      ); // Reload VM list when we enter the page.
     });
     refreshTimer = Timer.periodic(const Duration(seconds: 5), (Timer t) {
-      _getVms(context);
+      _getVms();
     }); // Reload VM list every 5 seconds.
   }
 
@@ -113,9 +116,9 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     });
   }
 
-  VmInfo _parseVmInfo(name) {
+  VmInfo _parseVmInfo(String name) {
     VmInfo info = VmInfo();
-    File portsFile = File(name + '/' + name + '.ports');
+    File portsFile = File('$name/$name.ports');
     if (portsFile.existsSync()) {
       List<String> lines = portsFile.readAsLinesSync();
       for (var line in lines) {
@@ -133,7 +136,7 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     return info;
   }
 
-  bool _isValidConf(conf) {
+  bool _isValidConf(String conf) {
     List<String> lines = File(conf).readAsLinesSync();
     for (var line in lines) {
       List<String> parts = line.split('=');
@@ -144,12 +147,14 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     return false;
   }
 
-  void _getVms(context) async {
+  void _getVms() async {
     List<String> currentVms = [];
     Map<String, VmInfo> activeVms = {};
 
-    await for (var entity
-        in Directory.current.list(recursive: false, followLinks: true)) {
+    await for (var entity in Directory.current.list(
+      recursive: false,
+      followLinks: true,
+    )) {
       if ((entity.path.endsWith('.conf')) && (_isValidConf(entity.path))) {
         String name = path.basenameWithoutExtension(entity.path);
         currentVms.add(name);
@@ -191,48 +196,40 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
   Widget _buildVmList() {
     List<Widget> widgetList = [];
     final Color buttonColor = Theme.of(context).colorScheme.primary;
-    widgetList.addAll(
-      [
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                "${context.t('Directory where the machines are stored')}:",
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
+    widgetList.addAll([
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              "${context.t('Directory where the machines are stored')}:",
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                foregroundColor: Theme.of(context).colorScheme.onSurface,
+                backgroundColor: Theme.of(context).colorScheme.surface,
               ),
-              const SizedBox(
-                width: 8,
-              ),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  foregroundColor: Theme.of(context).colorScheme.onSurface,
-                  backgroundColor: Theme.of(context).colorScheme.surface,
-                ),
-                onPressed: () async {
-                  var folder = await FilePicker.platform
-                      .getDirectoryPath(dialogTitle: "Pick a folder");
-                  if (folder != null) {
-                    setState(() {
-                      Directory.current = folder;
-                    });
-                    savePreference(
-                        prefWorkingDirectory, Directory.current.path);
-                  }
-                },
-                child: Text(Directory.current.path),
-              ),
-            ],
-          ),
+              onPressed: () async {
+                var folder = await FilePicker.getDirectoryPath(
+                  dialogTitle: "Pick a folder",
+                );
+                if (folder != null) {
+                  setState(() {
+                    Directory.current = folder;
+                  });
+                  savePreference(prefWorkingDirectory, Directory.current.path);
+                }
+              },
+              child: Text(Directory.current.path),
+            ),
+          ],
         ),
-        const Divider(
-          thickness: 2,
-        ),
-      ],
-    );
+      ),
+      const Divider(thickness: 2),
+    ]);
     List<List<Widget>> rows = _currentVms.map((vm) {
       return _buildRow(vm, buttonColor);
     }).toList();
@@ -240,10 +237,7 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
       widgetList.addAll(row);
     }
 
-    return ListView(
-      padding: const EdgeInsets.all(16.0),
-      children: widgetList,
-    );
+    return ListView(padding: const EdgeInsets.all(16.0), children: widgetList);
   }
 
   List<Widget> _buildRow(String currentVm, Color buttonColor) {
@@ -276,153 +270,162 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
     while (vmStem.contains('-')) {
       vmStem = vmStem.substring(0, vmStem.lastIndexOf('-'));
       if (osIcons.containsKey(vmStem)) {
-        osIcon = SvgPicture.asset(
-          osIcons[vmStem]!,
-          width: 32,
-          height: 32,
-        );
+        osIcon = SvgPicture.asset(osIcons[vmStem]!, width: 32, height: 32);
         break;
       }
     }
     return <Widget>[
       ListTile(
-          leading: osIcon ?? const Icon(Icons.computer, size: 32),
-          title: Text(currentVm),
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              IconButton(
-                  icon: Icon(
-                    active ? Icons.play_arrow : Icons.play_arrow_outlined,
-                    color: active ? Colors.green : buttonColor,
-                    semanticLabel: active ? 'Running' : 'Run',
-                  ),
-                  onPressed: active
-                      ? null
-                      : () async {
-                          Map<String, VmInfo> activeVms = _activeVms;
-                          List<String> command = [
-                            'quickemu',
-                            '--vm',
-                            '$currentVm.conf'
-                          ];
-                          if (_spicy) {
-                            command.addAll(['--display', 'spice']);
-                          }
-                          var shell = Shell();
-                          await shell.run(command.join(' '));
-                          VmInfo info = _parseVmInfo(currentVm);
-                          activeVms[currentVm] = info;
-                          setState(() {
-                            _activeVms = activeVms;
-                          });
-                        }),
-              IconButton(
-                icon: Icon(
-                  active ? Icons.stop : Icons.stop_outlined,
-                  color: active ? Colors.red : null,
-                  semanticLabel: active ? 'Stop' : 'Not running',
-                ),
-                onPressed: !active
-                    ? null
-                    : () {
-                        showDialog<bool>(
-                          context: context,
-                          builder: (BuildContext context) => AlertDialog(
-                            title: Text(context.t('Stop The Virtual Machine?')),
-                            content: Text(context.t(
-                                'You are about to terminate the virtual machine {0}',
-                                args: [currentVm])),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, false),
-                                child: Text(context.t('Cancel')),
-                              ),
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, true),
-                                child: Text(context.t('OK')),
-                              ),
-                            ],
+        leading: osIcon ?? const Icon(Icons.computer, size: 32),
+        title: Text(currentVm),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            IconButton(
+              icon: Icon(
+                active ? Icons.play_arrow : Icons.play_arrow_outlined,
+                color: active ? Colors.green : buttonColor,
+                semanticLabel: active ? 'Running' : 'Run',
+              ),
+              onPressed: active
+                  ? null
+                  : () async {
+                      Map<String, VmInfo> activeVms = _activeVms;
+                      List<String> command = [
+                        'quickemu',
+                        '--vm',
+                        '$currentVm.conf',
+                      ];
+                      if (_spicy) {
+                        command.addAll(['--display', 'spice']);
+                      }
+                      var shell = Shell();
+                      await shell.run(command.join(' '));
+                      VmInfo info = _parseVmInfo(currentVm);
+                      activeVms[currentVm] = info;
+                      setState(() {
+                        _activeVms = activeVms;
+                      });
+                    },
+            ),
+            IconButton(
+              icon: Icon(
+                active ? Icons.stop : Icons.stop_outlined,
+                color: active ? Colors.red : null,
+                semanticLabel: active ? 'Stop' : 'Not running',
+              ),
+              onPressed: !active
+                  ? null
+                  : () {
+                      showDialog<bool>(
+                        context: context,
+                        builder: (BuildContext context) => AlertDialog(
+                          title: Text(context.t('Stop The Virtual Machine?')),
+                          content: Text(
+                            context.t(
+                              'You are about to terminate the virtual machine {0}',
+                              args: [currentVm],
+                            ),
                           ),
-                        ).then((result) async {
-                          result = result ?? false;
-                          if (result) {
-                            var shell = Shell();
-                            // If Quickemu is newer than 4.9.6, use the new --kill option
-                            // which is macOS compatible.
-                            var quickemuVersion =
-                                Version.parse(await fetchQuickemuVersion());
-                            if (quickemuVersion >= Version(4, 9, 6)) {
-                              shell.run([
+                          actions: <Widget>[
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, false),
+                              child: Text(context.t('Cancel')),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, true),
+                              child: Text(context.t('OK')),
+                            ),
+                          ],
+                        ),
+                      ).then((result) async {
+                        result = result ?? false;
+                        if (result) {
+                          var shell = Shell();
+                          // If Quickemu is newer than 4.9.6, use the new --kill option
+                          // which is macOS compatible.
+                          var quickemuVersion = Version.parse(
+                            await fetchQuickemuVersion(),
+                          );
+                          if (quickemuVersion >= Version(4, 9, 6)) {
+                            shell.run(
+                              [
                                 'quickemu',
                                 '--vm',
                                 '$currentVm.conf',
-                                '--kill'
-                              ].join(' '));
-                            } else {
-                              shell.run(['killall', currentVm].join(' '));
-                            }
-                            setState(() {
-                              _activeVms.remove(currentVm);
-                            });
+                                '--kill',
+                              ].join(' '),
+                            );
+                          } else {
+                            shell.run(['killall', currentVm].join(' '));
                           }
-                        });
-                      },
+                          setState(() {
+                            _activeVms.remove(currentVm);
+                          });
+                        }
+                      });
+                    },
+            ),
+            IconButton(
+              icon: Icon(
+                Icons.delete,
+                color: active ? null : buttonColor,
+                semanticLabel: 'Delete',
               ),
-              IconButton(
-                icon: Icon(Icons.delete,
-                    color: active ? null : buttonColor,
-                    semanticLabel: 'Delete'),
-                onPressed: active
-                    ? null
-                    : () {
-                        showDialog<String?>(
-                          context: context,
-                          builder: (BuildContext context) => AlertDialog(
-                            title: Text(
-                                context.t('Delete {0}', args: [currentVm])),
-                            content: Text(
-                              context.t(
-                                  'You are about to delete {0}. This cannot be undone. Would you like to delete the disk image but keep the configuration, or delete the whole VM?',
-                                  args: [currentVm]),
-                            ),
-                            actions: [
-                              TextButton(
-                                child: Text(context.t('Cancel')),
-                                onPressed: () =>
-                                    Navigator.pop(context, 'cancel'),
-                              ),
-                              TextButton(
-                                child: Text(context.t('Delete disk image')),
-                                onPressed: () => Navigator.pop(context, 'disk'),
-                              ),
-                              TextButton(
-                                child: Text(context.t('Delete whole VM')),
-                                onPressed: () => Navigator.pop(context, 'vm'),
-                              ) // set up the AlertDialog
-                            ],
+              onPressed: active
+                  ? null
+                  : () {
+                      showDialog<String?>(
+                        context: context,
+                        builder: (BuildContext context) => AlertDialog(
+                          title: Text(
+                            context.t('Delete {0}', args: [currentVm]),
                           ),
-                        ).then((result) async {
-                          result = result ?? 'cancel';
-                          if (result != 'cancel') {
-                            List<String> command = [
-                              'quickemu',
-                              '--vm',
-                              '$currentVm.conf',
-                              '--delete-$result'
-                            ];
-                            var shell = Shell();
-                            await shell.run(command.join(' '));
-                          }
-                        });
-                      },
-              ),
-            ],
-          )),
+                          content: Text(
+                            context.t(
+                              'You are about to delete {0}. This cannot be undone. Would you like to delete the disk image but keep the configuration, or delete the whole VM?',
+                              args: [currentVm],
+                            ),
+                          ),
+                          actions: [
+                            TextButton(
+                              child: Text(context.t('Cancel')),
+                              onPressed: () => Navigator.pop(context, 'cancel'),
+                            ),
+                            TextButton(
+                              child: Text(context.t('Delete disk image')),
+                              onPressed: () => Navigator.pop(context, 'disk'),
+                            ),
+                            TextButton(
+                              child: Text(context.t('Delete whole VM')),
+                              onPressed: () => Navigator.pop(context, 'vm'),
+                            ), // set up the AlertDialog
+                          ],
+                        ),
+                      ).then((result) async {
+                        result = result ?? 'cancel';
+                        if (result != 'cancel') {
+                          List<String> command = [
+                            'quickemu',
+                            '--vm',
+                            '$currentVm.conf',
+                            '--delete-$result',
+                          ];
+                          var shell = Shell();
+                          await shell.run(command.join(' '));
+                        }
+                      });
+                    },
+            ),
+          ],
+        ),
+      ),
       if (connectInfo.isNotEmpty)
         ListTile(
-            title: Text(connectInfo, style: const TextStyle(fontSize: 12)),
-            trailing: Row(mainAxisSize: MainAxisSize.min, children: <Widget>[
+          title: Text(connectInfo, style: const TextStyle(fontSize: 12)),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
               IconButton(
                 icon: Icon(
                   Icons.monitor,
@@ -440,10 +443,14 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
                       },
               ),
               IconButton(
-                icon: SvgPicture.asset('assets/images/console.svg',
-                    semanticsLabel: 'Connect with SSH',
-                    colorFilter: ColorFilter.mode(
-                        sshy ? buttonColor : Colors.grey, BlendMode.srcIn)),
+                icon: SvgPicture.asset(
+                  'assets/images/console.svg',
+                  semanticsLabel: 'Connect with SSH',
+                  colorFilter: ColorFilter.mode(
+                    sshy ? buttonColor : Colors.grey,
+                    BlendMode.srcIn,
+                  ),
+                ),
                 tooltip: sshy
                     ? context.t('Connect with SSH')
                     : context.t('SSH server not detected on guest'),
@@ -464,7 +471,8 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
                             content: TextField(
                               controller: usernameController,
                               decoration: InputDecoration(
-                                  hintText: context.t("SSH username")),
+                                hintText: context.t("SSH username"),
+                              ),
                             ),
                             actions: <Widget>[
                               TextButton(
@@ -487,15 +495,16 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
                               'ssh',
                               '-p',
                               vmInfo.sshPort!,
-                              '${usernameController.text}@localhost'
+                              '${usernameController.text}@localhost',
                             ];
                             // Set the arguments to execute the ssh command in the default terminal.
                             // Strip the extension as x-terminal-emulator may point to a .wrapper
-                            switch (path
-                                .basenameWithoutExtension(_terminalEmulator!)) {
+                            switch (path.basenameWithoutExtension(
+                              _terminalEmulator!,
+                            )) {
                               case 'osascript':
                                 sshArgs = [
-                                  '-e \'tell app "Terminal" to do script "${sshArgs.join(' ')}"\''
+                                  '-e \'tell app "Terminal" to do script "${sshArgs.join(' ')}"\'',
                                 ];
                                 break;
                               case 'gnome-terminal':
@@ -532,17 +541,17 @@ class _ManagerState extends State<Manager> with PreferencesMixin {
                         });
                       },
               ),
-            ])),
-      const Divider()
+            ],
+          ),
+        ),
+      const Divider(),
     ];
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(context.t('Manager')),
-      ),
+      appBar: AppBar(title: Text(context.t('Manager'))),
       body: _buildVmList(),
     );
   }

--- a/lib/src/pages/operating_system_selection.dart
+++ b/lib/src/pages/operating_system_selection.dart
@@ -33,9 +33,7 @@ class _OperatingSystemSelectionState extends State<OperatingSystemSelection> {
           child: Padding(
             padding: const EdgeInsets.all(8.0),
             child: Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).canvasColor,
-              ),
+              decoration: BoxDecoration(color: Theme.of(context).canvasColor),
               child: Padding(
                 padding: const EdgeInsets.all(8),
                 child: Material(
@@ -47,7 +45,8 @@ class _OperatingSystemSelectionState extends State<OperatingSystemSelection> {
                         child: TextField(
                           focusNode: focusNode,
                           decoration: InputDecoration.collapsed(
-                              hintText: context.t('Search operating system')),
+                            hintText: context.t('Search operating system'),
+                          ),
                           onChanged: (value) {
                             setState(() {
                               term = value;
@@ -71,7 +70,10 @@ class _OperatingSystemSelectionState extends State<OperatingSystemSelection> {
               builder: (BuildContext context, AsyncSnapshot<List> snapshot) {
                 if (snapshot.hasData) {
                   List list = snapshot.data!
-                      .where((os) => os.name.toLowerCase().contains(term.toLowerCase()))
+                      .where(
+                        (os) =>
+                            os.name.toLowerCase().contains(term.toLowerCase()),
+                      )
                       .toList();
                   return ListView.builder(
                     padding: const EdgeInsets.only(top: 4),
@@ -109,18 +111,18 @@ class _OperatingSystemSelectionState extends State<OperatingSystemSelection> {
                       Column(
                         children: [
                           const Padding(
-                              padding: EdgeInsets.all(16.0),
-                              child: CircularProgressIndicator()
+                            padding: EdgeInsets.all(16.0),
+                            child: CircularProgressIndicator(),
                           ),
                           Text(context.t('Loading available downloads')),
                         ],
-                      )
+                      ),
                     ],
                   );
                 }
-              }
+              },
             ),
-          ]
+          ],
         ),
       ),
     );

--- a/lib/src/pages/option_selection.dart
+++ b/lib/src/pages/option_selection.dart
@@ -52,7 +52,8 @@ class _OptionSelectionState extends State<OptionSelection> {
                               child: TextField(
                                 focusNode: focusNode,
                                 decoration: InputDecoration.collapsed(
-                                    hintText: context.t('Search option')),
+                                  hintText: context.t('Search option'),
+                                ),
                                 onChanged: (value) {
                                   setState(() {
                                     term = value;

--- a/lib/src/pages/version_selection.dart
+++ b/lib/src/pages/version_selection.dart
@@ -13,7 +13,7 @@ class VersionSelection extends StatefulWidget {
   final OperatingSystem operatingSystem;
 
   @override
-  _VersionSelectionState createState() => _VersionSelectionState();
+  State<VersionSelection> createState() => _VersionSelectionState();
 }
 
 class _VersionSelectionState extends State<VersionSelection> {
@@ -29,22 +29,26 @@ class _VersionSelectionState extends State<VersionSelection> {
   @override
   Widget build(BuildContext context) {
     var list = widget.operatingSystem.versions
-        .where((version) =>
-            version.version.toLowerCase().contains(term.toLowerCase()))
+        .where(
+          (version) =>
+              version.version.toLowerCase().contains(term.toLowerCase()),
+        )
         .toList();
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(context
-            .t('Select version for {0}', args: [widget.operatingSystem.name])),
+        title: Text(
+          context.t(
+            'Select version for {0}',
+            args: [widget.operatingSystem.name],
+          ),
+        ),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(kToolbarHeight),
           child: Padding(
             padding: const EdgeInsets.all(8.0),
             child: Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).canvasColor,
-              ),
+              decoration: BoxDecoration(color: Theme.of(context).canvasColor),
               child: Padding(
                 padding: const EdgeInsets.all(8),
                 child: Material(
@@ -88,19 +92,27 @@ class _VersionSelectionState extends State<VersionSelection> {
                     onTap: () {
                       if (item.options.length > 1) {
                         Navigator.of(context)
-                            .push<Option>(MaterialPageRoute(
+                            .push<Option>(
+                              MaterialPageRoute(
                                 fullscreenDialog: true,
                                 builder: (context) =>
-                                    OptionSelection(list[index])))
+                                    OptionSelection(list[index]),
+                              ),
+                            )
                             .then((selection) {
-                          if (selection != null) {
-                            Navigator.of(context)
-                                .pop(Tuple2<Version, Option?>(item, selection));
-                          }
-                        });
+                              if (selection != null && context.mounted) {
+                                Navigator.of(context).pop(
+                                  Tuple2<Version, Option?>(item, selection),
+                                );
+                              }
+                            });
                       } else {
-                        Navigator.of(context).pop(Tuple2<Version, Option?>(
-                            item, list[index].options[0]));
+                        Navigator.of(context).pop(
+                          Tuple2<Version, Option?>(
+                            item,
+                            list[index].options[0],
+                          ),
+                        );
                       }
                     },
                   ),

--- a/lib/src/widgets/downloader/cancel_dismiss_button.dart
+++ b/lib/src/widgets/downloader/cancel_dismiss_button.dart
@@ -31,7 +31,7 @@ class CancelDismissButton extends StatelessWidget {
             child: downloadFinished
                 ? Text(context.t('Dismiss'))
                 : Text(context.t('Cancel')),
-          )
+          ),
         ],
       ),
     );

--- a/lib/src/widgets/downloader/download_label.dart
+++ b/lib/src/widgets/downloader/download_label.dart
@@ -20,13 +20,17 @@ class DownloadLabel extends StatelessWidget {
       child: downloadFinished
           ? Text(context.t('Download finished.'))
           : data != null
-              ? downloader != 'zsync'
-                  ? downloader == 'curl' || downloader == ''
-                      ? Text(context.t('Downloading... {0}%',
-                          args: [(data! * 100).toInt()]))
+          ? downloader != 'zsync'
+                ? downloader == 'curl' || downloader == ''
+                      ? Text(
+                          context.t(
+                            'Downloading... {0}%',
+                            args: [(data! * 100).toInt()],
+                          ),
+                        )
                       : Text(context.t('{0} Mbs downloaded', args: [data!]))
-                  : Text(context.t("Downloading (no progress available)..."))
-              : Text(context.t('Waiting for download to start')),
+                : Text(context.t("Downloading (no progress available)..."))
+          : Text(context.t('Waiting for download to start')),
     );
   }
 }

--- a/lib/src/widgets/downloader/download_progress_bar.dart
+++ b/lib/src/widgets/downloader/download_progress_bar.dart
@@ -16,9 +16,7 @@ class DownloadProgressBar extends StatelessWidget {
       padding: const EdgeInsets.all(8.0),
       child: SizedBox(
         width: 200,
-        child: LinearProgressIndicator(
-          value: downloadFinished ? 1 : data,
-        ),
+        child: LinearProgressIndicator(value: downloadFinished ? 1 : data),
       ),
     );
   }

--- a/lib/src/widgets/home_page/downloader_menu.dart
+++ b/lib/src/widgets/home_page/downloader_menu.dart
@@ -44,23 +44,24 @@ class _DownloaderMenuState extends State<DownloaderMenu> with PreferencesMixin {
                       color: Theme.of(context).colorScheme.onPrimaryContainer,
                     ),
                   ),
-                  const SizedBox(
-                    width: 8,
-                  ),
+                  const SizedBox(width: 8),
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       foregroundColor: Theme.of(context).colorScheme.onSurface,
                       backgroundColor: Theme.of(context).colorScheme.surface,
                     ),
                     onPressed: () async {
-                      var folder = await FilePicker.platform
-                          .getDirectoryPath(dialogTitle: "Pick a folder");
+                      var folder = await FilePicker.getDirectoryPath(
+                        dialogTitle: "Pick a folder",
+                      );
                       if (folder != null) {
                         setState(() {
                           Directory.current = folder;
                         });
                         savePreference(
-                            prefWorkingDirectory, Directory.current.path);
+                          prefWorkingDirectory,
+                          Directory.current.path,
+                        );
                       }
                     },
                     child: Text(Directory.current.path),
@@ -68,9 +69,7 @@ class _DownloaderMenuState extends State<DownloaderMenu> with PreferencesMixin {
                 ],
               ),
             ),
-            const Divider(
-              thickness: 2,
-            ),
+            const Divider(thickness: 2),
             const Row(
               children: [
                 Expanded(
@@ -80,7 +79,7 @@ class _DownloaderMenuState extends State<DownloaderMenu> with PreferencesMixin {
                       Padding(
                         padding: EdgeInsets.symmetric(horizontal: 12),
                         child: HomePageButtonGroup(),
-                      )
+                      ),
                     ],
                   ),
                 ),

--- a/lib/src/widgets/home_page/downloader_page_button.dart
+++ b/lib/src/widgets/home_page/downloader_page_button.dart
@@ -26,9 +26,7 @@ class DownloaderPageButton extends StatelessWidget {
               child: Center(
                 child: Text(
                   label?.toUpperCase() ?? '',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleSmall
+                  style: Theme.of(context).textTheme.titleSmall
                       ?.copyWith(color: Colors.white),
                 ),
               ),

--- a/lib/src/widgets/home_page/home_page_button.dart
+++ b/lib/src/widgets/home_page/home_page_button.dart
@@ -24,9 +24,7 @@ class HomePageButton extends StatelessWidget {
             Center(
               child: Text(
                 label?.toUpperCase() ?? '',
-                style: Theme.of(context)
-                    .textTheme
-                    .titleSmall
+                style: Theme.of(context).textTheme.titleSmall
                     ?.copyWith(color: Colors.white),
               ),
             ),

--- a/lib/src/widgets/home_page/home_page_button_group.dart
+++ b/lib/src/widgets/home_page/home_page_button_group.dart
@@ -41,24 +41,28 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
           text: _selectedOperatingSystem?.name ?? context.t('Select...'),
           onPressed: () {
             Navigator.of(context)
-                .push<OperatingSystem>(MaterialPageRoute(
+                .push<OperatingSystem>(
+                  MaterialPageRoute(
                     fullscreenDialog: true,
-                    builder: (context) => const OperatingSystemSelection()))
+                    builder: (context) => const OperatingSystemSelection(),
+                  ),
+                )
                 .then((selection) {
-              if (selection != null) {
-                setState(() {
-                  _selectedOperatingSystem = selection;
-                  if (selection.versions.length == 1 &&
-                      selection.versions.first.options.length == 1) {
-                    _selectedVersion = selection.versions.first;
-                    _selectedOption = selection.versions.first.options.first;
-                  } else {
-                    _selectedVersion = null;
-                    _selectedOption = null;
+                  if (selection != null) {
+                    setState(() {
+                      _selectedOperatingSystem = selection;
+                      if (selection.versions.length == 1 &&
+                          selection.versions.first.options.length == 1) {
+                        _selectedVersion = selection.versions.first;
+                        _selectedOption =
+                            selection.versions.first.options.first;
+                      } else {
+                        _selectedVersion = null;
+                        _selectedOption = null;
+                      }
+                    });
                   }
                 });
-              }
-            });
           },
         ),
         DownloaderPageButton(
@@ -67,19 +71,22 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
           onPressed: (_selectedOperatingSystem != null)
               ? () {
                   Navigator.of(context)
-                      .push<Tuple2<Version, Option?>>(MaterialPageRoute(
-                    fullscreenDialog: true,
-                    builder: (context) => VersionSelection(
-                        operatingSystem: _selectedOperatingSystem!),
-                  ))
+                      .push<Tuple2<Version, Option?>>(
+                        MaterialPageRoute(
+                          fullscreenDialog: true,
+                          builder: (context) => VersionSelection(
+                            operatingSystem: _selectedOperatingSystem!,
+                          ),
+                        ),
+                      )
                       .then((selection) {
-                    if (selection != null) {
-                      setState(() {
-                        _selectedVersion = selection.item1;
-                        _selectedOption = selection.item2;
+                        if (selection != null) {
+                          setState(() {
+                            _selectedVersion = selection.item1;
+                            _selectedOption = selection.item2;
+                          });
+                        }
                       });
-                    }
-                  });
                 }
               : null,
         ),
@@ -89,8 +96,9 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
           onPressed: (_selectedVersion == null)
               ? null
               : () async {
-                  final workingDirectory =
-                      await getPreference<String>(prefWorkingDirectory);
+                  final workingDirectory = await getPreference<String>(
+                    prefWorkingDirectory,
+                  );
                   final tmpFile = File("$workingDirectory/modecheck.tmp");
                   if (tmpFile.existsSync()) {
                     tmpFile.deleteSync();
@@ -103,6 +111,7 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
                   if (tmpFile.existsSync()) {
                     tmpFile.deleteSync();
 
+                    if (!context.mounted) return;
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (context) => Downloader(
@@ -113,13 +122,15 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
                       ),
                     );
                   } else {
+                    if (!context.mounted) return;
                     showDialog(
                       context: context,
                       builder: (context) => AlertDialog(
                         title: Text(context.t('Error')),
                         content: Text(
                           context.t(
-                              'Could not write to the working directory. Please check the permissions.'),
+                            'Could not write to the working directory. Please check the permissions.',
+                          ),
                         ),
                         actions: [
                           TextButton(
@@ -156,20 +167,18 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
               children: [
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 32),
-                  child: Text(context.t('Downloading...'),
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyLarge
-                          ?.copyWith(color: Colors.white)),
+                  child: Text(
+                    context.t('Downloading...'),
+                    style: Theme.of(context).textTheme.bodyLarge
+                        ?.copyWith(color: Colors.white),
+                  ),
                 ),
                 const CircularProgressIndicator(),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 32),
                   child: Text(
                     'Target : ${Directory.current.absolute.path}',
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyLarge
+                    style: Theme.of(context).textTheme.bodyLarge
                         ?.copyWith(color: Colors.white),
                   ),
                 ),
@@ -185,8 +194,10 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
     Navigator.of(context).pop();
   }
 
-  void showDoneDialog(
-      {required String operatingSystem, required String version}) {
+  void showDoneDialog({
+    required String operatingSystem,
+    required String version,
+  }) {
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -204,19 +215,20 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
               children: [
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 32),
-                  child: Text(context.t('Done !'),
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyLarge
-                          ?.copyWith(color: Colors.white)),
+                  child: Text(
+                    context.t('Done !'),
+                    style: Theme.of(context).textTheme.bodyLarge
+                        ?.copyWith(color: Colors.white),
+                  ),
                 ),
                 Text(
-                    context.t('Now run {0} to start the VM',
-                        args: ["quickemu --vm $operatingSystem-$version"]),
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyLarge
-                        ?.copyWith(color: Colors.white)),
+                  context.t(
+                    'Now run {0} to start the VM',
+                    args: ["quickemu --vm $operatingSystem-$version"],
+                  ),
+                  style: Theme.of(context).textTheme.bodyLarge
+                      ?.copyWith(color: Colors.white),
+                ),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 32),
                   child: ElevatedButton(
@@ -225,9 +237,7 @@ class _HomePageButtonGroupState extends State<HomePageButtonGroup>
                     },
                     child: Text(
                       'Dismiss',
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyLarge
+                      style: Theme.of(context).textTheme.bodyLarge
                           ?.copyWith(color: Colors.white),
                     ),
                   ),

--- a/lib/src/widgets/left_menu.dart
+++ b/lib/src/widgets/left_menu.dart
@@ -55,56 +55,57 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                     .add(const EdgeInsets.symmetric(horizontal: 16)),
                 child: Container(
                   padding: const EdgeInsets.symmetric(vertical: 4.0),
-                  child: Text("Quickgui $version",
-                      style: const TextStyle(
-                          fontSize: 24.0, fontWeight: FontWeight.bold)),
+                  child: Text(
+                    "Quickgui $version",
+                    style: const TextStyle(
+                      fontSize: 24.0,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                 ),
               ),
               FutureBuilder<String>(
                 future: fetchQuickemuVersion(),
                 builder:
                     (BuildContext context, AsyncSnapshot<String> snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return const CircularProgressIndicator(); // or some other widget while waiting
-                  } else {
-                    String poweredByText =
-                        "${context.t('Powered by')} Quickemu";
-                    if (snapshot.hasData) {
-                      poweredByText += " ${snapshot.data}";
-                    }
-                    return Padding(
-                      // Minimal top padding
-                      padding: const EdgeInsets.only(top: 0)
-                          .add(const EdgeInsets.symmetric(horizontal: 16)),
-                      child: Container(
-                        child: Text(poweredByText,
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const CircularProgressIndicator(); // or some other widget while waiting
+                      } else {
+                        String poweredByText =
+                            "${context.t('Powered by')} Quickemu";
+                        if (snapshot.hasData) {
+                          poweredByText += " ${snapshot.data}";
+                        }
+                        return Padding(
+                          // Minimal top padding
+                          padding: const EdgeInsets.only(top: 0)
+                              .add(const EdgeInsets.symmetric(horizontal: 16)),
+                          child: Text(
+                            poweredByText,
                             style: const TextStyle(
-                                fontSize: 12.0, fontWeight: FontWeight.bold)),
-                      ),
-                    );
-                  }
-                },
+                              fontSize: 12.0,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        );
+                      }
+                    },
               ),
-              Container(
-                height: 4.0,
-              ),
+              Container(height: 4.0),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Row(
                   children: [
                     Text(
                       context.t('Use dark mode'),
-                      style: TextStyle(
-                        color: Colors.grey[300],
-                      ),
+                      style: TextStyle(color: Colors.grey[300]),
                     ),
-                    Expanded(
-                      child: Container(),
-                    ),
+                    Expanded(child: Container()),
                     Switch(
-                      value: Theme.of(context).colorScheme.brightness ==
+                      value:
+                          Theme.of(context).colorScheme.brightness ==
                           Brightness.dark,
-                      activeColor: Colors.black26,
+                      activeThumbColor: Colors.black26,
                       activeTrackColor: Theme.of(context).colorScheme.primary,
                       inactiveThumbColor: Colors.grey[500],
                       inactiveTrackColor: Colors.grey[300],
@@ -122,17 +123,13 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                   ],
                 ),
               ),
-              Container(
-                height: 4.0,
-              ),
+              Container(height: 4.0),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Row(
                   children: [
                     Text(context.t('Language')),
-                    Expanded(
-                      child: Container(),
-                    ),
+                    Expanded(child: Container()),
                     DropdownButton<String>(
                       value: currentLocale,
                       items: _dropdownMenuItems,
@@ -147,9 +144,7 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                   ],
                 ),
               ),
-              Container(
-                height: 32.0,
-              ),
+              Container(height: 32.0),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Column(
@@ -160,8 +155,9 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                         style: DefaultTextStyle.of(context).style,
                         children: const <TextSpan>[
                           TextSpan(
-                              text: 'Authors\n',
-                              style: TextStyle(fontWeight: FontWeight.bold)),
+                            text: 'Authors\n',
+                            style: TextStyle(fontWeight: FontWeight.bold),
+                          ),
                           TextSpan(text: 'Yannick Mauray\n'),
                           TextSpan(text: 'Mark Johnson\n'),
                           TextSpan(text: 'Martin Wimpress\n'),
@@ -175,8 +171,9 @@ class _LeftMenuState extends State<LeftMenu> with PreferencesMixin {
                         children: const <TextSpan>[
                           TextSpan(text: '© 2021 - 2024\n'),
                           TextSpan(
-                              text: 'Quickemu Project\n',
-                              style: TextStyle(fontWeight: FontWeight.bold)),
+                            text: 'Quickemu Project\n',
+                            style: TextStyle(fontWeight: FontWeight.bold),
+                          ),
                         ],
                       ),
                     ),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker_darwin
 import package_info_plus
 import shared_preferences_foundation
 import url_launcher_macos
 import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,41 +1,22 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - package_info_plus (0.0.1):
-    - FlutterMacOS
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
   - window_size (0.0.2):
     - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_size (from `Flutter/ephemeral/.symlinks/plugins/window_size/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
-  package_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  shared_preferences_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_size:
     :path: Flutter/ephemeral/.symlinks/plugins/window_size/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
-  window_size: 339dafa0b27a95a62a843042038fa6c3c48de195
+  FlutterMacOS: c232990155153907050900a2e175c7773903ba4e
+  window_size: 4bd15034e6e3d0720fd77928a7c42e5492cfece9
 
-PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
+PODFILE CHECKSUM: f0c21717cb7ee9112f915044c74bfceb5b12e02a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.17.0

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		556376D73D985479212CC116 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA7153C071C61C298B27A8E /* Pods_RunnerTests.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		C0B7021831AC0B71E4AF216A /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		D7B8DA22B0A54BBE9BCBC89F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7FA05E1CC5B19461025C6AD /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				1BE543F3FBBB4C06DEC7A142 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -164,6 +167,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -230,6 +234,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		33CC10EC2044A3C60003C045 /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -255,6 +262,9 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -477,7 +487,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "quickemu-project.quickgui.RunnerTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -493,7 +503,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "quickemu-project.quickgui.RunnerTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -509,7 +519,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "quickemu-project.quickgui.RunnerTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -559,7 +569,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -585,7 +595,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -595,7 +605,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Profile;
@@ -647,7 +657,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -697,7 +707,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -723,7 +733,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -748,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -758,7 +768,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Manual;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -767,7 +777,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -816,6 +826,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "quickgui.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -59,6 +77,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
 </plist>

--- a/package.nix
+++ b/package.nix
@@ -3,11 +3,11 @@
 , copyDesktopItems
 , lib
 , flutter
-, gnome
+, zenity
 , quickemu
 }:
 let
-  runtimeBinDependencies = [ quickemu gnome.zenity ];
+  runtimeBinDependencies = [ quickemu zenity ];
   versionMatches = builtins.match ''
     .*
     .*version:[[:blank:]]([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\+?[[:digit:]]*)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _discoveryapis_commons
-      sha256: "113c4100b90a5b70a983541782431b82168b3cae166ab130649c36eb3559d498"
+      sha256: "55dd9e9cb83f8b62aa5dd8744d3bfedf79d33f9457c1684916c2b5c69c6e3a9b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.8"
+  android_file_picker:
+    dependency: transitive
+    description:
+      name: android_file_picker
+      sha256: "0d84bb91fb78af33756107f00cf71ee084474169d481b882b335c3006077a913"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   ansicolor:
     dependency: transitive
     description:
@@ -29,26 +37,26 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   buffer:
     dependency: transitive
     description:
@@ -61,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   charset:
     dependency: transitive
     description:
@@ -77,34 +85,34 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      sha256: "89b8801ba49f8b593fbf2d3e59efd0f566c46cd4ba6837ae2610c72b52a0f899"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.6.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: e51d50bca3217c9a9fa2b41a30e4a38971133f5f9ec7a3d57bae095007f1d28e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   console:
     dependency: transitive
     description:
@@ -125,34 +133,34 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4+2"
+    version: "0.3.5+5"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      sha256: a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.15"
   desktop_notifications:
     dependency: "direct main"
     description:
@@ -165,34 +173,50 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8"
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
+  fastforge:
+    dependency: "direct dev"
+    description:
+      name: fastforge
+      sha256: "5c1075060b1a86686cf4ecd160132935c7c22757caafc526e57990b347bf3d5b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.12"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -205,10 +229,42 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "16dc141db5a2ccc6520ebb6a2eb5945b1b09e95085c021d9f914f8ded7f1465c"
+      sha256: "0631f51bbc2e1184bdc9e79384db158dc7830e15b3001feeca700e86563f4d24"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.4"
+    version: "12.2.0"
+  file_picker_darwin:
+    dependency: transitive
+    description:
+      name: file_picker_darwin
+      sha256: "5c32c9400f5c8976c9dd7aa34693c7d2f0c853c28704a1c1409029cb760f5251"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_picker_linux:
+    dependency: transitive
+    description:
+      name: file_picker_linux
+      sha256: bd52ff1e0048f29df95f913c55ad2991c72791d93e6c42241912c4bdee946cb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: file_picker_platform_interface
+      sha256: d35d8cb68446fae921335bb61501d66cb2469d74c8f3103b8c6ccdbe3fe5afd8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  file_picker_web:
+    dependency: transitive
+    description:
+      name: file_picker_web
+      sha256: "935560a9d29fa6f006f2855addebb88e88d438e13627d4cc24187033c106f227"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -218,63 +274,47 @@ packages:
     dependency: transitive
     description:
       name: flutter_app_builder
-      sha256: "75b9be9ba8b67d445a117368f7e603228e8a434136c71a3051307fc727be74f4"
+      sha256: "50818c02875c2a370e1fc337795d2dc8807c73702670f39613704155f9b47622"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.2"
   flutter_app_packager:
     dependency: transitive
     description:
       name: flutter_app_packager
-      sha256: "93ec9ecc30f43f764a8388d68ea8aed66ce9bbf76f482e0120c6f45add6eea21"
+      sha256: dea2cff9dd3e0129427206412add1d9584388eb6acd83308e172bcd39e93e5e4
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.11"
   flutter_app_publisher:
     dependency: transitive
     description:
       name: flutter_app_publisher
-      sha256: ebaf6b01e0d28f4d5abc4959fcde3692a2f0d5297148507fb3590fe10a55d5dd
+      sha256: "495fa2f1e2b72edf4518bd2ced283f2ca23c9dcd6b3bb267df1022e5f78c1013"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.6"
-  flutter_distributor:
-    dependency: "direct dev"
-    description:
-      name: flutter_distributor
-      sha256: e139769ab3e7d58bd29c17e7da6f9001c626b0d50a375b5a374ba7bc91114037
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.6"
+    version: "0.6.10"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: "9ee02950848f61c4129af3d6ec84a1cfc0e47931abc746b03e7a3bc3e8ff6eda"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.22"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: d44bf546b13025ec7353091516f6881f1d4c633993cb109c3916c3a0159dadf1
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -289,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: get_it
-      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
+      sha256: "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66"
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.0"
+    version: "9.2.1"
   gettext:
     dependency: "direct main"
     description:
@@ -321,18 +361,18 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: "218aeb56050c714f62a3182775320dfa04602b55074873e24e31bbd39bda96fb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   google_identity_services_web:
     dependency: transitive
     description:
       name: google_identity_services_web
-      sha256: "55580f436822d64c8ff9a77e37d61f5fb1e6c7ec9d632a43ee324e2a05c3c6c9"
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.3+1"
   googleapis:
     dependency: transitive
     description:
@@ -353,18 +393,18 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
@@ -377,58 +417,58 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: "2635216ca6a737e60de577ffa1a48a0bec76ca8a62917cfc1bb88c14c570646f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "6.1.0"
   liquid_engine:
     dependency: transitive
     description:
@@ -449,34 +489,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      sha256: bd47de35f07e27267e69c8c8b22edf9473bfee170a60d60fcc93730c5144b7f6
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   minio:
     dependency: transitive
     description:
@@ -489,18 +529,26 @@ packages:
     dependency: transitive
     description:
       name: msix
-      sha256: c50d6bd1aafe0d071a3c1e5a5ccb056404502935cb0a549e3178c4aae16caf33
+      sha256: "61415c352e8aea084332b8a5514e6408c961c8cdeca202804fff1040eb555ac7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.8"
+    version: "3.18.0"
   mustache_template:
     dependency: transitive
     description:
       name: mustache_template
-      sha256: a46e26f91445bfb0b60519be280555b06792460b27b19e2b19ad5b9740df5d1c
+      sha256: c689b4d59176f8c7a2860aab765d205916aa5b06cfafff7613bfcc42fa996143
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.5"
+  mutex:
+    dependency: transitive
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   nested:
     dependency: transitive
     description:
@@ -513,26 +561,26 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   parse_app_package:
     dependency: transitive
     description:
@@ -542,13 +590,13 @@ packages:
     source: hosted
     version: "0.6.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -561,18 +609,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -585,10 +633,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -597,6 +645,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
+  platform_info:
+    dependency: transitive
+    description:
+      name: platform_info
+      sha256: "61f3bd25642d6624b3d3111892b517cdb17c37a1837189fee346fcc6dd09b052"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   plist_parser:
     dependency: transitive
     description:
@@ -617,42 +673,42 @@ packages:
     dependency: "direct main"
     description:
       name: process_run
-      sha256: c917dfb5f7afad4c7485bc00a4df038621248fce046105020cea276d1a87c820
+      sha256: "1f05b1b0da2448b64805e9fdc16e6fed011ae766102ea41f9a6bf65a688a2e05"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.5"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      sha256: "261236774e8b1d69cfc6b9eabbc96c40f25e7a2d6b171f3385d4f65d5734fb24"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
+      sha256: c38b81cbf34450b67e0265d73433569d12e34782e30ed769c9cc99c9d5f2e796
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.6.0"
   qiniu_sdk_base:
     dependency: transitive
     description:
       name: qiniu_sdk_base
-      sha256: "2506c6372512f81cfbddf162ea6da1ad7b1c6521dee1d10e9da6847c92e13349"
+      sha256: "1487f8db30e998a75a63ace68018de7644c92f2f81102ca1ee95fdb6e88307e0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.8.0"
   quiver:
     dependency: "direct main"
     description:
@@ -673,26 +729,26 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "95f9997ca1fb9799d494d0cb2a780fd7be075818d59f00c43832ed112b158a82"
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.5.5"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "480ba4345773f56acda9abf5f50bd966f581dac5d514e5fc4a18c62976bbba7e"
+      sha256: "1e12aafe408aa50da80edfd679a2a6bf63ba7ab37c7fa98286da459a757b3399"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.28"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      sha256: "2ec3934efa51e46117f23031cc141b8fc878e8525b94ec1ea4f7f586cf1b47ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.7"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -705,18 +761,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -741,67 +797,75 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  singleflight:
+    dependency: transitive
+    description:
+      name: singleflight
+      sha256: "820397a683df8fce2a695b892134014fb7996a18a04cb845be8fd4f58741f440"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "277654b3034d17ac6f9f1cb5595db011b1d5d41e8806866db28e0abaa101c490"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.2"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      sha256: "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0+1"
+    version: "3.4.1+2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.12"
   tuple:
     dependency: "direct main"
     description:
@@ -814,58 +878,58 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   unified_distributor:
     dependency: transitive
     description:
       name: unified_distributor
-      sha256: "4adea66430c915b46a498364fa31070ce86ad798e322d10621461c9fb2bc03be"
+      sha256: "45d0c276c761eab68b61e8750ff27dedf3630a31476f595ee8d58ef17836617a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.12"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
+      sha256: "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.9"
+    version: "6.3.33"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      sha256: "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.4.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      sha256: "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
+      sha256: "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.6"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -878,58 +942,50 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
+      sha256: "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.7"
+    version: "3.1.6"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "27d5fefe86fb9aace4a9f8375b56b3c292b64d8c04510df230f849850d912cb7"
+      sha256: "9d0e3b9cb16542ad660daee871e726a10d13a93b7b5391677c3160e8f5e83935"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.15"
+    version: "1.2.3"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "2430b973a4ca3c4dbc9999b62b8c719a160100dcbae5c819bae0cacce32c9cdb"
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.12"
+    version: "1.1.13"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad"
+      sha256: "4dca4feb77dc3ec7f6e27e49c53241eb8217f55e4f9b12599a27f8903bca5682"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.16"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.4.2"
   version:
     dependency: "direct main"
     description:
@@ -942,26 +998,26 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "15.3.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "68d1e89a91ed61ad9c370f9f8b6effed9ae5e0ede22a270bdfa6daf79fc2290a"
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.4"
+    version: "6.4.0"
   window_size:
     dependency: "direct main"
     description:
@@ -971,6 +1027,14 @@ packages:
       url: "https://github.com/google/flutter-desktop-embedding.git"
     source: git
     version: "0.1.0"
+  windows_file_picker:
+    dependency: transitive
+    description:
+      name: windows_file_picker
+      sha256: d999c1c085374724668af0b674a9758d96255c50933faa2ac1cc51eff8308caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -983,18 +1047,18 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: f67cdd8e07d3c6329146aaef1ba043542b3134c12489f553ca9a7435d1068aea
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.13.0 <4.0.0"
+  flutter: "3.47.2"

--- a/pubspec.lock.json
+++ b/pubspec.lock.json
@@ -4,11 +4,21 @@
       "dependency": "transitive",
       "description": {
         "name": "_discoveryapis_commons",
-        "sha256": "113c4100b90a5b70a983541782431b82168b3cae166ab130649c36eb3559d498",
+        "sha256": "55dd9e9cb83f8b62aa5dd8744d3bfedf79d33f9457c1684916c2b5c69c6e3a9b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.7"
+      "version": "1.0.8"
+    },
+    "android_file_picker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "android_file_picker",
+        "sha256": "0d84bb91fb78af33756107f00cf71ee084474169d481b882b335c3006077a913",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
     },
     "ansicolor": {
       "dependency": "transitive",
@@ -34,41 +44,51 @@
       "dependency": "transitive",
       "description": {
         "name": "args",
-        "sha256": "bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6",
+        "sha256": "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.0"
+      "version": "2.7.0"
     },
     "async": {
       "dependency": "transitive",
       "description": {
         "name": "async",
-        "sha256": "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c",
+        "sha256": "e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.11.0"
+      "version": "2.13.1"
     },
     "boolean_selector": {
       "dependency": "transitive",
       "description": {
         "name": "boolean_selector",
-        "sha256": "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66",
+        "sha256": "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "2.1.2"
+    },
+    "buffer": {
+      "dependency": "transitive",
+      "description": {
+        "name": "buffer",
+        "sha256": "389da2ec2c16283c8787e0adaede82b1842102f8c8aae2f49003a766c5c6b3d1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.3"
     },
     "characters": {
       "dependency": "transitive",
       "description": {
         "name": "characters",
-        "sha256": "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605",
+        "sha256": "faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.0"
+      "version": "1.4.1"
     },
     "charset": {
       "dependency": "transitive",
@@ -84,41 +104,41 @@
       "dependency": "transitive",
       "description": {
         "name": "checked_yaml",
-        "sha256": "feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff",
+        "sha256": "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.3"
+      "version": "2.0.4"
     },
     "cli_util": {
       "dependency": "transitive",
       "description": {
         "name": "cli_util",
-        "sha256": "ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c",
+        "sha256": "89b8801ba49f8b593fbf2d3e59efd0f566c46cd4ba6837ae2610c72b52a0f899",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.2"
+      "version": "0.6.0"
     },
     "clock": {
       "dependency": "transitive",
       "description": {
         "name": "clock",
-        "sha256": "cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf",
+        "sha256": "e51d50bca3217c9a9fa2b41a30e4a38971133f5f9ec7a3d57bae095007f1d28e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.1"
+      "version": "1.1.3"
     },
     "collection": {
       "dependency": "transitive",
       "description": {
         "name": "collection",
-        "sha256": "ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a",
+        "sha256": "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.18.0"
+      "version": "1.19.1"
     },
     "console": {
       "dependency": "transitive",
@@ -130,45 +150,55 @@
       "source": "hosted",
       "version": "4.1.0"
     },
+    "convert": {
+      "dependency": "transitive",
+      "description": {
+        "name": "convert",
+        "sha256": "b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.2"
+    },
     "cross_file": {
       "dependency": "transitive",
       "description": {
         "name": "cross_file",
-        "sha256": "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670",
+        "sha256": "f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.4+2"
+      "version": "0.3.5+5"
     },
     "crypto": {
       "dependency": "transitive",
       "description": {
         "name": "crypto",
-        "sha256": "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855",
+        "sha256": "c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.6"
+      "version": "3.0.7"
     },
     "cupertino_icons": {
       "dependency": "direct main",
       "description": {
         "name": "cupertino_icons",
-        "sha256": "ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6",
+        "sha256": "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.8"
+      "version": "1.0.9"
     },
     "dbus": {
       "dependency": "transitive",
       "description": {
         "name": "dbus",
-        "sha256": "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac",
+        "sha256": "a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.10"
+      "version": "0.7.15"
     },
     "desktop_notifications": {
       "dependency": "direct main",
@@ -184,41 +214,61 @@
       "dependency": "transitive",
       "description": {
         "name": "dio",
-        "sha256": "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260",
+        "sha256": "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.7.0"
+      "version": "5.11.0"
     },
     "dio_web_adapter": {
       "dependency": "transitive",
       "description": {
         "name": "dio_web_adapter",
-        "sha256": "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8",
+        "sha256": "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "2.2.1"
     },
     "fake_async": {
       "dependency": "transitive",
       "description": {
         "name": "fake_async",
-        "sha256": "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78",
+        "sha256": "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.1"
+      "version": "1.3.3"
+    },
+    "fastforge": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "fastforge",
+        "sha256": "5c1075060b1a86686cf4ecd160132935c7c22757caafc526e57990b347bf3d5b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.12"
     },
     "ffi": {
       "dependency": "transitive",
       "description": {
         "name": "ffi",
-        "sha256": "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6",
+        "sha256": "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.3"
+      "version": "2.2.0"
+    },
+    "ffi_leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi_leak_tracker",
+        "sha256": "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
     },
     "file": {
       "dependency": "transitive",
@@ -234,11 +284,51 @@
       "dependency": "direct main",
       "description": {
         "name": "file_picker",
-        "sha256": "16dc141db5a2ccc6520ebb6a2eb5945b1b09e95085c021d9f914f8ded7f1465c",
+        "sha256": "0631f51bbc2e1184bdc9e79384db158dc7830e15b3001feeca700e86563f4d24",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.1.4"
+      "version": "12.2.0"
+    },
+    "file_picker_darwin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_picker_darwin",
+        "sha256": "5c32c9400f5c8976c9dd7aa34693c7d2f0c853c28704a1c1409029cb760f5251",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "file_picker_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_picker_linux",
+        "sha256": "bd52ff1e0048f29df95f913c55ad2991c72791d93e6c42241912c4bdee946cb9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "file_picker_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_picker_platform_interface",
+        "sha256": "d35d8cb68446fae921335bb61501d66cb2469d74c8f3103b8c6ccdbe3fe5afd8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.3.0"
+    },
+    "file_picker_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_picker_web",
+        "sha256": "935560a9d29fa6f006f2855addebb88e88d438e13627d4cc24187033c106f227",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
     },
     "flutter": {
       "dependency": "direct main",
@@ -250,51 +340,41 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_app_builder",
-        "sha256": "74018c0e2da3ae33073e7417b5c8e900fdc7b5ebc3bdacd2dd05244d9b5e54cb",
+        "sha256": "50818c02875c2a370e1fc337795d2dc8807c73702670f39613704155f9b47622",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.5"
+      "version": "0.6.2"
     },
     "flutter_app_packager": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_app_packager",
-        "sha256": "3925c4e2ac53f4a5ce3bae1a5f54966620504d6c28725b112074cfbdf227a36b",
+        "sha256": "dea2cff9dd3e0129427206412add1d9584388eb6acd83308e172bcd39e93e5e4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.5"
+      "version": "0.6.11"
     },
     "flutter_app_publisher": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_app_publisher",
-        "sha256": "bbb1953ef723fc98a7f974ae9499194999f570194c6d856182518e6e73b51ff2",
+        "sha256": "495fa2f1e2b72edf4518bd2ced283f2ca23c9dcd6b3bb267df1022e5f78c1013",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.5"
-    },
-    "flutter_distributor": {
-      "dependency": "direct dev",
-      "description": {
-        "name": "flutter_distributor",
-        "sha256": "45d27526a5de93370e322da5314b0a1c07c024b79031a8ad44435046915fa0e8",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.4.5"
+      "version": "0.6.10"
     },
     "flutter_lints": {
       "dependency": "direct dev",
       "description": {
         "name": "flutter_lints",
-        "sha256": "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c",
+        "sha256": "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.0.0"
+      "version": "6.0.0"
     },
     "flutter_localizations": {
       "dependency": "direct main",
@@ -302,25 +382,15 @@
       "source": "sdk",
       "version": "0.0.0"
     },
-    "flutter_plugin_android_lifecycle": {
-      "dependency": "transitive",
-      "description": {
-        "name": "flutter_plugin_android_lifecycle",
-        "sha256": "9b78450b89f059e96c9ebb355fa6b3df1d6b330436e0b885fb49594c41721398",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.23"
-    },
     "flutter_svg": {
       "dependency": "direct main",
       "description": {
         "name": "flutter_svg",
-        "sha256": "54900a1a1243f3c4a5506d853a2b5c2dbc38d5f27e52a52618a8054401431123",
+        "sha256": "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.16"
+      "version": "2.3.0"
     },
     "flutter_test": {
       "dependency": "direct dev",
@@ -338,11 +408,11 @@
       "dependency": "transitive",
       "description": {
         "name": "get_it",
-        "sha256": "d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1",
+        "sha256": "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.7.0"
+      "version": "9.2.1"
     },
     "gettext": {
       "dependency": "direct main",
@@ -378,21 +448,21 @@
       "dependency": "transitive",
       "description": {
         "name": "glob",
-        "sha256": "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63",
+        "sha256": "218aeb56050c714f62a3182775320dfa04602b55074873e24e31bbd39bda96fb",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.2.0"
     },
     "google_identity_services_web": {
       "dependency": "transitive",
       "description": {
         "name": "google_identity_services_web",
-        "sha256": "55580f436822d64c8ff9a77e37d61f5fb1e6c7ec9d632a43ee324e2a05c3c6c9",
+        "sha256": "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.3"
+      "version": "0.3.3+1"
     },
     "googleapis": {
       "dependency": "transitive",
@@ -418,21 +488,21 @@
       "dependency": "transitive",
       "description": {
         "name": "http",
-        "sha256": "b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010",
+        "sha256": "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.2"
+      "version": "1.6.0"
     },
     "http_parser": {
       "dependency": "transitive",
       "description": {
         "name": "http_parser",
-        "sha256": "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b",
+        "sha256": "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.0.2"
+      "version": "4.1.2"
     },
     "image": {
       "dependency": "transitive",
@@ -448,71 +518,71 @@
       "dependency": "transitive",
       "description": {
         "name": "intl",
-        "sha256": "d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf",
+        "sha256": "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.19.0"
+      "version": "0.20.3"
     },
     "io": {
       "dependency": "transitive",
       "description": {
         "name": "io",
-        "sha256": "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e",
+        "sha256": "2635216ca6a737e60de577ffa1a48a0bec76ca8a62917cfc1bb88c14c570646f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.4"
+      "version": "1.1.0"
     },
     "json_annotation": {
       "dependency": "transitive",
       "description": {
         "name": "json_annotation",
-        "sha256": "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1",
+        "sha256": "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.9.0"
+      "version": "4.12.0"
     },
     "leak_tracker": {
       "dependency": "transitive",
       "description": {
         "name": "leak_tracker",
-        "sha256": "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05",
+        "sha256": "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.0.5"
+      "version": "11.0.2"
     },
     "leak_tracker_flutter_testing": {
       "dependency": "transitive",
       "description": {
         "name": "leak_tracker_flutter_testing",
-        "sha256": "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806",
+        "sha256": "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.5"
+      "version": "3.0.10"
     },
     "leak_tracker_testing": {
       "dependency": "transitive",
       "description": {
         "name": "leak_tracker_testing",
-        "sha256": "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3",
+        "sha256": "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.1"
+      "version": "3.0.2"
     },
     "lints": {
       "dependency": "transitive",
       "description": {
         "name": "lints",
-        "sha256": "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235",
+        "sha256": "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.0.0"
+      "version": "6.1.0"
     },
     "liquid_engine": {
       "dependency": "transitive",
@@ -538,51 +608,81 @@
       "dependency": "transitive",
       "description": {
         "name": "matcher",
-        "sha256": "d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb",
+        "sha256": "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.12.16+1"
+      "version": "0.12.20"
     },
     "material_color_utilities": {
       "dependency": "transitive",
       "description": {
         "name": "material_color_utilities",
-        "sha256": "f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec",
+        "sha256": "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.11.1"
+      "version": "0.13.0"
     },
     "meta": {
       "dependency": "transitive",
       "description": {
         "name": "meta",
-        "sha256": "bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7",
+        "sha256": "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.15.0"
+      "version": "1.19.0"
+    },
+    "mime": {
+      "dependency": "transitive",
+      "description": {
+        "name": "mime",
+        "sha256": "bd47de35f07e27267e69c8c8b22edf9473bfee170a60d60fcc93730c5144b7f6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "minio": {
+      "dependency": "transitive",
+      "description": {
+        "name": "minio",
+        "sha256": "ee2ce47766e46c7d164f960f2f5ed6a9a82844d877f6b82574f6876ec50c56d1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.5.8"
     },
     "msix": {
       "dependency": "transitive",
       "description": {
         "name": "msix",
-        "sha256": "c50d6bd1aafe0d071a3c1e5a5ccb056404502935cb0a549e3178c4aae16caf33",
+        "sha256": "61415c352e8aea084332b8a5514e6408c961c8cdeca202804fff1040eb555ac7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.16.8"
+      "version": "3.18.0"
     },
     "mustache_template": {
       "dependency": "transitive",
       "description": {
         "name": "mustache_template",
-        "sha256": "a46e26f91445bfb0b60519be280555b06792460b27b19e2b19ad5b9740df5d1c",
+        "sha256": "c689b4d59176f8c7a2860aab765d205916aa5b06cfafff7613bfcc42fa996143",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "2.0.5"
+    },
+    "mutex": {
+      "dependency": "transitive",
+      "description": {
+        "name": "mutex",
+        "sha256": "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
     },
     "nested": {
       "dependency": "transitive",
@@ -598,51 +698,51 @@
       "dependency": "transitive",
       "description": {
         "name": "package_config",
-        "sha256": "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd",
+        "sha256": "ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.0"
+      "version": "3.0.0"
     },
     "package_info_plus": {
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "da8d9ac8c4b1df253d1a328b7bf01ae77ef132833479ab40763334db13b91cce",
+        "sha256": "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.1.1"
+      "version": "10.2.1"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "package_info_plus_platform_interface",
-        "sha256": "ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66",
+        "sha256": "db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.1"
+      "version": "4.1.0"
     },
     "parse_app_package": {
       "dependency": "transitive",
       "description": {
         "name": "parse_app_package",
-        "sha256": "69f313fbadf457576015333a8da2e99018763dce88df248febcfb8883da8aedb",
+        "sha256": "8ff00a930da628d5270f58f2befbbf10185ed7959b093195985bf4132e84bc8a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.5"
+      "version": "0.6.0"
     },
     "path": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "path",
-        "sha256": "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af",
+        "sha256": "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.9.0"
+      "version": "1.9.1"
     },
     "path_parsing": {
       "dependency": "transitive",
@@ -658,21 +758,21 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_linux",
-        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "path_provider_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_platform_interface",
-        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "sha256": "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     "path_provider_windows": {
       "dependency": "transitive",
@@ -688,11 +788,11 @@
       "dependency": "transitive",
       "description": {
         "name": "petitparser",
-        "sha256": "c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27",
+        "sha256": "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.0.2"
+      "version": "7.0.2"
     },
     "platform": {
       "dependency": "transitive",
@@ -703,6 +803,16 @@
       },
       "source": "hosted",
       "version": "3.1.6"
+    },
+    "platform_info": {
+      "dependency": "transitive",
+      "description": {
+        "name": "platform_info",
+        "sha256": "61f3bd25642d6624b3d3111892b517cdb17c37a1837189fee346fcc6dd09b052",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.2"
     },
     "plist_parser": {
       "dependency": "transitive",
@@ -728,51 +838,51 @@
       "dependency": "direct main",
       "description": {
         "name": "process_run",
-        "sha256": "a68fa9727392edad97a2a96a77ce8b0c17d28336ba1b284b1dfac9595a4299ea",
+        "sha256": "1f05b1b0da2448b64805e9fdc16e6fed011ae766102ea41f9a6bf65a688a2e05",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.2+1"
+      "version": "1.3.5"
     },
     "provider": {
       "dependency": "direct main",
       "description": {
         "name": "provider",
-        "sha256": "c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c",
+        "sha256": "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.1.2"
+      "version": "6.1.5+1"
     },
     "pub_semver": {
       "dependency": "transitive",
       "description": {
         "name": "pub_semver",
-        "sha256": "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c",
+        "sha256": "261236774e8b1d69cfc6b9eabbc96c40f25e7a2d6b171f3385d4f65d5734fb24",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.4"
+      "version": "2.2.1"
     },
     "pubspec_parse": {
       "dependency": "transitive",
       "description": {
         "name": "pubspec_parse",
-        "sha256": "c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8",
+        "sha256": "c38b81cbf34450b67e0265d73433569d12e34782e30ed769c9cc99c9d5f2e796",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.0"
+      "version": "1.6.0"
     },
     "qiniu_sdk_base": {
       "dependency": "transitive",
       "description": {
         "name": "qiniu_sdk_base",
-        "sha256": "2506c6372512f81cfbddf162ea6da1ad7b1c6521dee1d10e9da6847c92e13349",
+        "sha256": "1487f8db30e998a75a63ace68018de7644c92f2f81102ca1ee95fdb6e88307e0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.2"
+      "version": "0.8.0"
     },
     "quiver": {
       "dependency": "direct main",
@@ -798,31 +908,31 @@
       "dependency": "direct main",
       "description": {
         "name": "shared_preferences",
-        "sha256": "95f9997ca1fb9799d494d0cb2a780fd7be075818d59f00c43832ed112b158a82",
+        "sha256": "c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.3"
+      "version": "2.5.5"
     },
     "shared_preferences_android": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "7f172d1b06de5da47b6264c2692ee2ead20bbbc246690427cdb4fc301cd0c549",
+        "sha256": "1e12aafe408aa50da80edfd679a2a6bf63ba7ab37c7fa98286da459a757b3399",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.4"
+      "version": "2.4.28"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_foundation",
-        "sha256": "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d",
+        "sha256": "2ec3934efa51e46117f23031cc141b8fc878e8525b94ec1ea4f7f586cf1b47ea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.3"
+      "version": "2.5.7"
     },
     "shared_preferences_linux": {
       "dependency": "transitive",
@@ -838,21 +948,21 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_platform_interface",
-        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
+        "sha256": "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "shared_preferences_web": {
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_web",
-        "sha256": "d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e",
+        "sha256": "c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.2"
+      "version": "2.4.3"
     },
     "shared_preferences_windows": {
       "dependency": "transitive",
@@ -868,97 +978,107 @@
       "dependency": "transitive",
       "description": {
         "name": "shell_executor",
-        "sha256": "9c024546fc96470a6b96be9902f0bc05347a017a7638ed8d93c77e8d77eb3c3c",
+        "sha256": "6f41c85bffc7e839401bebc8c75cb189896ff038072060d3b0ec538949b615fc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.1.6"
+      "version": "0.3.0"
     },
     "shell_uikit": {
       "dependency": "transitive",
       "description": {
         "name": "shell_uikit",
-        "sha256": "03703090807091514ace2f9c8dc5d9b2d18c42a248c767220167825fbc3d2747",
+        "sha256": "8d5bb6bb0b220d47ef11adbe001cb31944b8eb8fe6183687258d36c9320d6c75",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.1.1"
+      "version": "0.3.0"
+    },
+    "singleflight": {
+      "dependency": "transitive",
+      "description": {
+        "name": "singleflight",
+        "sha256": "820397a683df8fce2a695b892134014fb7996a18a04cb845be8fd4f58741f440",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
     },
     "sky_engine": {
       "dependency": "transitive",
       "description": "flutter",
       "source": "sdk",
-      "version": "0.0.99"
+      "version": "0.0.0"
     },
     "source_span": {
       "dependency": "transitive",
       "description": {
         "name": "source_span",
-        "sha256": "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c",
+        "sha256": "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.10.0"
+      "version": "1.10.2"
     },
     "stack_trace": {
       "dependency": "transitive",
       "description": {
         "name": "stack_trace",
-        "sha256": "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b",
+        "sha256": "277654b3034d17ac6f9f1cb5595db011b1d5d41e8806866db28e0abaa101c490",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.11.1"
+      "version": "1.12.2"
     },
     "stream_channel": {
       "dependency": "transitive",
       "description": {
         "name": "stream_channel",
-        "sha256": "ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7",
+        "sha256": "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.4"
     },
     "string_scanner": {
       "dependency": "transitive",
       "description": {
         "name": "string_scanner",
-        "sha256": "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde",
+        "sha256": "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.0"
+      "version": "1.4.1"
     },
     "synchronized": {
       "dependency": "transitive",
       "description": {
         "name": "synchronized",
-        "sha256": "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225",
+        "sha256": "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.3.0+3"
+      "version": "3.4.1+2"
     },
     "term_glyph": {
       "dependency": "transitive",
       "description": {
         "name": "term_glyph",
-        "sha256": "a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84",
+        "sha256": "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "test_api": {
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb",
+        "sha256": "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.2"
+      "version": "0.7.12"
     },
     "tuple": {
       "dependency": "direct main",
@@ -980,55 +1100,65 @@
       "source": "hosted",
       "version": "1.4.0"
     },
+    "unified_distributor": {
+      "dependency": "transitive",
+      "description": {
+        "name": "unified_distributor",
+        "sha256": "45d0c276c761eab68b61e8750ff27dedf3630a31476f595ee8d58ef17836617a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.12"
+    },
     "url_launcher": {
       "dependency": "direct main",
       "description": {
         "name": "url_launcher",
-        "sha256": "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603",
+        "sha256": "f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.1"
+      "version": "6.3.2"
     },
     "url_launcher_android": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193",
+        "sha256": "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.14"
+      "version": "6.3.33"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_ios",
-        "sha256": "e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e",
+        "sha256": "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.1"
+      "version": "6.4.2"
     },
     "url_launcher_linux": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_linux",
-        "sha256": "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935",
+        "sha256": "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.1"
+      "version": "3.2.3"
     },
     "url_launcher_macos": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_macos",
-        "sha256": "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672",
+        "sha256": "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.1"
+      "version": "3.2.6"
     },
     "url_launcher_platform_interface": {
       "dependency": "transitive",
@@ -1044,71 +1174,61 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_web",
-        "sha256": "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e",
+        "sha256": "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.3"
+      "version": "2.4.3"
     },
     "url_launcher_windows": {
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_windows",
-        "sha256": "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4",
+        "sha256": "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.3"
-    },
-    "uuid": {
-      "dependency": "transitive",
-      "description": {
-        "name": "uuid",
-        "sha256": "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.0.7"
+      "version": "3.1.6"
     },
     "vector_graphics": {
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics",
-        "sha256": "27d5fefe86fb9aace4a9f8375b56b3c292b64d8c04510df230f849850d912cb7",
+        "sha256": "9d0e3b9cb16542ad660daee871e726a10d13a93b7b5391677c3160e8f5e83935",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.15"
+      "version": "1.2.3"
     },
     "vector_graphics_codec": {
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics_codec",
-        "sha256": "2430b973a4ca3c4dbc9999b62b8c719a160100dcbae5c819bae0cacce32c9cdb",
+        "sha256": "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.12"
+      "version": "1.1.13"
     },
     "vector_graphics_compiler": {
       "dependency": "transitive",
       "description": {
         "name": "vector_graphics_compiler",
-        "sha256": "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad",
+        "sha256": "4dca4feb77dc3ec7f6e27e49c53241eb8217f55e4f9b12599a27f8903bca5682",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.16"
+      "version": "1.3.0"
     },
     "vector_math": {
       "dependency": "transitive",
       "description": {
         "name": "vector_math",
-        "sha256": "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803",
+        "sha256": "f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.4"
+      "version": "2.4.2"
     },
     "version": {
       "dependency": "direct main",
@@ -1124,31 +1244,31 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d",
+        "sha256": "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "14.2.5"
+      "version": "15.3.0"
     },
     "web": {
       "dependency": "transitive",
       "description": {
         "name": "web",
-        "sha256": "cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb",
+        "sha256": "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "win32": {
       "dependency": "transitive",
       "description": {
         "name": "win32",
-        "sha256": "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69",
+        "sha256": "a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.9.0"
+      "version": "6.4.0"
     },
     "window_size": {
       "dependency": "direct main",
@@ -1160,6 +1280,16 @@
       },
       "source": "git",
       "version": "0.1.0"
+    },
+    "windows_file_picker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "windows_file_picker",
+        "sha256": "d999c1c085374724668af0b674a9758d96255c50933faa2ac1cc51eff8308caf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
     },
     "xdg_directories": {
       "dependency": "transitive",
@@ -1175,25 +1305,25 @@
       "dependency": "transitive",
       "description": {
         "name": "xml",
-        "sha256": "b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226",
+        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.5.0"
+      "version": "6.6.1"
     },
     "yaml": {
       "dependency": "transitive",
       "description": {
         "name": "yaml",
-        "sha256": "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5",
+        "sha256": "f67cdd8e07d3c6329146aaef1ba043542b3134c12489f553ca9a7435d1068aea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.1.2"
+      "version": "3.1.4"
     }
   },
   "sdks": {
-    "dart": ">=3.5.0 <4.0.0",
-    "flutter": ">=3.24.0"
+    "dart": ">=3.13.0 <4.0.0",
+    "flutter": "3.47.2"
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.2.10+1
 
 environment:
-  flutter: "3.22.0"
-  sdk: ">=3.2.0 <4.0.0"
+  flutter: "3.47.2"
+  sdk: ">=3.13.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -14,12 +14,13 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   desktop_notifications: ^0.6.3
-  file_picker: ^8.0.6
+  file_picker: ^12.2.0
   flutter_svg: ^2.1.0
   gettext: ^1.2.0
   gettext_i18n: ^1.0.7
   gettext_parser: ^0.2.0
-  package_info_plus: ^9.0.1
+  package_info_plus: ^10.2.1
+  path: ^1.9.1
   process_run: ^1.1.0
   provider: ^6.1.5
   quiver: ^3.2.2
@@ -36,8 +37,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_distributor: ^0.6.6
-  flutter_lints: ^4.0.0
+  fastforge: ^0.6.12
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/test/app_settings_test.dart
+++ b/test/app_settings_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quickgui/src/model/app_settings.dart';
+
+void main() {
+  test(
+    'normalizes an encoded locale and falls back for unsupported values',
+    () {
+      final settings = AppSettings();
+      settings.setActiveLocaleSilently('en_US.UTF-8');
+      expect(settings.languageCode, 'en');
+      settings.setActiveLocaleSilently('unsupported_LOCALE');
+      expect(settings.activeLocale, 'en');
+    },
+  );
+}

--- a/test/asset_manifest_test.dart
+++ b/test/asset_manifest_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quickgui/main.dart' as app;
+import 'package:quickgui/src/model/osicons.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loads OS icons from the bundled binary asset manifest', () async {
+    final previousIcons = Map<String, String>.of(osIcons);
+    addTearDown(() {
+      osIcons
+        ..clear()
+        ..addAll(previousIcons);
+    });
+    osIcons.clear();
+
+    // Use the asset bundle produced by Flutter, without a mock manifest.
+    await expectLater(
+      rootBundle.loadString('AssetManifest.json'),
+      throwsA(isA<FlutterError>()),
+    );
+    rootBundle.evict('AssetManifest.json');
+
+    await app.getIcons();
+
+    expect(osIcons, containsPair('ubuntu', 'assets/quickemu-icons/ubuntu.svg'));
+    expect(
+      osIcons,
+      containsPair('windows', 'assets/quickemu-icons/windows.svg'),
+    );
+    expect(osIcons, containsPair('macos', 'assets/quickemu-icons/macos.svg'));
+    expect(await rootBundle.loadString(osIcons['ubuntu']!), contains('<svg'));
+  });
+}


### PR DESCRIPTION
# Description

Align the desktop project and dependency locks with Flutter 3.47.2 / Dart 3.13 so the configured SDK, native plugins and build jobs use a compatible toolchain. Read OS icons through Flutter's binary `AssetManifest` API and finish loading them before starting the UI. The new packaged-asset regression test fails against the old JSON manifest loader and passes with this change.

Update the file picker call sites and declare user-selected read/write access in both macOS entitlement files. The resolved Darwin file picker checks these entitlements before opening a dialog. The existing screen layout is retained.

The Nix build uses a separate pinned Flutter input while retaining the existing Quickemu runtime input. Packaging commands use fastforge 0.6.12. CI adds formatting, analysis, tests and a macOS build, covers all pull requests to main, and keeps PPA/FlakeHub publishing restricted to the upstream repository.

**Compatibility change:** this raises the macOS deployment target from 10.14 to 12.0 and requires Flutter 3.47.2 / Dart 3.13 for source builds.

Related work: #303 covers the asset-manifest/startup problem; this patch uses Flutter's binary manifest API. #322 updates the packaging dependency that this patch replaces with fastforge. #317 also changes flake.lock and should be reconciled before merging. This PR does not close those broader proposals automatically.

## Type of change

- [x] Bug fix
- [x] Packaging/build updates
- [x] Breaking change: macOS minimum version and source toolchain requirements

## Validation

Submitted head: `448e7e4922ec804578908f41ef07778deacf4dd2`; base: `74949e086154f3f2d555f9268778545c78ff2b51`.

- `flutter pub get --enforce-lockfile`: passed, committed lockfile unchanged.
- `dart format --output=none --set-exit-if-changed lib test`: passed, 32 files unchanged.
- `flutter analyze --no-pub`: passed, no issues.
- `flutter test --no-pub --reporter expanded`: passed, 2 tests. The new asset test fails with the old loader (`AssetManifest.json` is absent from the generated bundle).
- macOS Release build, bundle signature and runtime entitlements: passed on Intel macOS 15.7.9 (47.2 MB). Both the runner and App.framework contain x86_64 and arm64 slices; the signed app contains the file-picker entitlement; the built asset bundle contains AssetManifest.bin.
- Submitted-head Linux/macOS/Nix CI: [passed on the fork](https://github.com/kimdongup/quickgui/actions/runs/34558437055): analysis/tests, Linux, Nix and macOS all succeeded; PPA was skipped by the repository condition.
- Upstream title validation passed. The [upstream build run](https://github.com/quickemu-project/quickgui/actions/runs/34558542663) is `action_required` pending workflow approval.
- YAML/JSON dependency locks match; both entitlement files pass plist validation.

The existing window_size Swift Package Manager warning remains; the macOS build uses the CocoaPods fallback and exits 0.

This PR covers the build/startup compatibility foundation. Full installed-guest GUI acceptance and release-format packaging/publishing have not been validated on this branch. The macOS bundle is ad-hoc signed, not notarized. Further VM lifecycle and workspace fixes will follow as separate changes.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested the compatibility paths listed above.
- [x] I have updated and committed pubspec.yaml, pubspec.lock and pubspec.lock.json.
- [ ] Full installed-guest GUI acceptance on Linux and macOS.

